### PR TITLE
feat: Update NuGet workflow

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -39,12 +39,6 @@ jobs:
             - name: Create the package
               run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }} /p:AssemblyVersion=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }} /p:Version=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }} AuroraControlsMaui/AuroraControls.Maui.csproj
 
-            - name: Publish the package to GPR
-              run: |
-                  foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
-                      dotnet nuget push $file
-                  }
-
               # Publish the NuGet package as an artifact, so they can be used in the following jobs
             - uses: actions/upload-artifact@v3
               with:
@@ -52,3 +46,6 @@ jobs:
                   if-no-files-found: error
                   retention-days: 7
                   path: ${{ env.NuGetDirectory }}/*.nupkg
+
+            - name: Publish the package to GPR
+              run: dotnet nuget push ${{ env.NuGetDirectory }}/*.nupkg


### PR DESCRIPTION
- Set environment variables for skipping first-time experience and disabling logo
- Specify NuGet directory as a workspace path
- Update dotnet version to 7.x
- Change source URL for NuGet packages
- Build Aurora Controls MAUI project using updated csproj file name
- Create package with specified configuration and versioning parameters
- Publish the package to GitHub Package Registry (GPR)
- Push all generated .nupkg files to GPR using PowerShell script
- Upload NuGet packages as artifacts for future use
