### PR TITLE
feat: Update NuGet workflow

### DIFF
--- a/AuroraControlsMaui/AuroraControls.Maui.csproj
+++ b/AuroraControlsMaui/AuroraControls.Maui.csproj
@@ -8,6 +8,7 @@
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
         <AssemblyName>AuroraControls</AssemblyName>
+        <PackageId>AuroraControls.Maui</PackageId>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-ios|AnyCPU'">
         <CreatePackage>false</CreatePackage>


### PR DESCRIPTION
- Set environment variables for skipping first-time experience and disabling logo
- Specify NuGet directory as a workspace path
- Update dotnet version to 7.x
- Change source URL for NuGet packages
- Build Aurora Controls MAUI project using updated csproj file name
- Create package with specified configuration and versioning parameters
- Publish the package to GitHub Package Registry (GPR)
- Push all generated .nupkg files to GPR using PowerShell script
- Upload NuGet packages as artifacts for future use
