### PR TITLE
Add NuGet package publishing to GitHub Actions workflow

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -49,3 +49,6 @@ jobs:
 
             - name: Publish the package to GPR
               run: dotnet nuget push ${{ env.NuGetDirectory }}/*.nupkg
+
+            - name: Publish the package to NuGet
+              run: dotnet nuget push ${{ env.NuGetDirectory }}/*.nupkg --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
- Added a step to publish the package to NuGet
- The package is pushed using the dotnet nuget push command with necessary parameters
