### PR TITLE
Add IsTrimmable property to AuroraControls.Maui.csproj

### DIFF
--- a/AuroraControlsMaui/AuroraControls.Maui.csproj
+++ b/AuroraControlsMaui/AuroraControls.Maui.csproj
@@ -7,6 +7,7 @@
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
+        <IsTrimmable>true</IsTrimmable>
         <AssemblyName>AuroraControls</AssemblyName>
         <PackageId>AuroraControls.Maui</PackageId>
     </PropertyGroup>


### PR DESCRIPTION
This commit adds the IsTrimmable property to the AuroraControls.Maui.csproj file. This property allows for trimming of unused code during compilation.
