### PR TITLE
Add SVG icon support and clean up color handling

### DIFF
--- a/AuroraControls.TestApp/MainPage.cs
+++ b/AuroraControls.TestApp/MainPage.cs
@@ -62,6 +62,10 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
         ViewModel = new TestRxViewModel();
         MvvmToolkitViewModel = new TestMvvmToolkitViewModel();
 
+        this.ToolbarItems.Add(
+            new ToolbarItem()
+                .SetSvgIcon("more.svg"));
+
         Content =
             new ScrollView
             {

--- a/AuroraControls.TestApp/Resources/SVG/more.svg
+++ b/AuroraControls.TestApp/Resources/SVG/more.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="6px" height="22px" viewBox="0 0 6 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Shape</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Estimate-Details---self-storage" transform="translate(-640.000000, -27.000000)" fill="#FFFFFF" fill-rule="nonzero">
+            <g id="more" transform="translate(640.000000, 27.000000)">
+                <path d="M3,-8.8817842e-16 C1.34314575,-8.8817842e-16 0,1.34314575 0,3 C0,4.65685425 1.34314575,6 3,6 C4.65685425,6 6,4.65685425 6,3 C6,1.34314575 4.65685425,-8.8817842e-16 3,-8.8817842e-16 Z M3,8 C1.34314575,8 0,9.34314575 0,11 C0,12.6568542 1.34314575,14 3,14 C4.65685425,14 6,12.6568542 6,11 C6,9.34314575 4.65685425,8 3,8 Z M3,16 C1.34314575,16 0,17.3431458 0,19 C0,20.6568542 1.34314575,22 3,22 C4.65685425,22 6,20.6568542 6,19 C6,17.3431458 4.65685425,16 3,16 Z" id="Shape"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/AuroraControlsMaui/IIconCache.cs
+++ b/AuroraControlsMaui/IIconCache.cs
@@ -15,7 +15,7 @@ public interface IIconCache
     /// <param name="squareSize">The square size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<Image> IconFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color colorOverride = default(Color));
+    Task<Image> IconFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Fetches an SVG icon by name.
@@ -25,7 +25,7 @@ public interface IIconCache
     /// <param name="size">A Xamarin.Forms.Size representing the desired size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<Image> IconFromSvg(string svgName, Size size, string additionalCacheKey = "", Color colorOverride = default(Color));
+    Task<Image> IconFromSvg(string svgName, Size size, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Fetches an SVG source by name.
@@ -35,7 +35,7 @@ public interface IIconCache
     /// <param name="squareSize">The square size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<ImageSource> SourceFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color colorOverride = default(Color));
+    Task<ImageSource> SourceFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Fetches an SVG icon by name.
@@ -45,7 +45,7 @@ public interface IIconCache
     /// <param name="size">A Xamarin.Forms.Size representing the desired size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<ImageSource> SourceFromSvg(string svgName, Size size, string additionalCacheKey = "", Color colorOverride = default(Color));
+    Task<ImageSource> SourceFromSvg(string svgName, Size size, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Fetches an SVG icon by name.
@@ -56,7 +56,7 @@ public interface IIconCache
     /// <param name="squareSize">A double representing the desired size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<ImageSource> SourceFromRawSvg(string svgName, string svgValue, double squareSize = 22d, string additionalCacheKey = "", Color colorOverride = default(Color));
+    Task<ImageSource> SourceFromRawSvg(string svgName, string svgValue, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Fetches an SVG icon by name.
@@ -67,7 +67,7 @@ public interface IIconCache
     /// <param name="size">A Xamarin.Forms.Size representing the desired size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<ImageSource> SourceFromRawSvg(string svgName, string svgValue, Size size, string additionalCacheKey = "", Color colorOverride = default(Color));
+    Task<ImageSource> SourceFromRawSvg(string svgName, string svgValue, Size size, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Fetches an SVG file image source by name.
@@ -77,7 +77,7 @@ public interface IIconCache
     /// <param name="squareSize">The square size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<FileImageSource> FileImageSourceFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color colorOverride = default(Color));
+    Task<FileImageSource> FileImageSourceFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Fetches an SVG icon by name.
@@ -87,7 +87,7 @@ public interface IIconCache
     /// <param name="size">A Xamarin.Forms.Size representing the desired size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<FileImageSource> FileImageSourceFromSvg(string svgName, Size size, string additionalCacheKey = "", Color colorOverride = default(Color));
+    Task<FileImageSource> FileImageSourceFromSvg(string svgName, Size size, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Loads the assembly.

--- a/AuroraControlsMaui/IconCacheBase.cs
+++ b/AuroraControlsMaui/IconCacheBase.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using System.Text;
-using System.Xml;
 using Svg.Skia;
 
 namespace AuroraControls;
@@ -19,6 +18,8 @@ public abstract class IconCacheBase : IIconCache, IDisposable
 
     private readonly float _platformScalingFactor;
 
+    private readonly SKColorSpace _colorspace = SKColorSpace.CreateSrgb();
+
     private bool _disposedValue;
 
     public IconCacheBase()
@@ -27,12 +28,12 @@ public abstract class IconCacheBase : IIconCache, IDisposable
         _platformScalingFactor = (float)PlatformInfo.ScalingFactor;
     }
 
-    public Task<Image> IconFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color colorOverride = default(Color))
+    public Task<Image> IconFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = null)
     {
         return IconFromSvg(svgName, new Size(squareSize, squareSize), additionalCacheKey, colorOverride);
     }
 
-    public async Task<Image> IconFromSvg(string svgName, Size size, string additionalCacheKey = "", Color colorOverride = default(Color))
+    public async Task<Image> IconFromSvg(string svgName, Size size, string additionalCacheKey = "", Color? colorOverride = null)
     {
         return
             new Image()
@@ -41,12 +42,12 @@ public abstract class IconCacheBase : IIconCache, IDisposable
             };
     }
 
-    public Task<ImageSource> SourceFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color colorOverride = default(Color))
+    public Task<ImageSource> SourceFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = null)
     {
         return SourceFromSvg(svgName, new Size(squareSize, squareSize), additionalCacheKey, colorOverride);
     }
 
-    public async Task<ImageSource> SourceFromSvg(string svgName, Size size, string additionalCacheKey = "", Color colorOverride = default(Color))
+    public async Task<ImageSource> SourceFromSvg(string svgName, Size size, string additionalCacheKey = "", Color? colorOverride = null)
     {
         var key = CreateIconKey(svgName, size, additionalCacheKey, colorOverride);
 
@@ -87,12 +88,12 @@ public abstract class IconCacheBase : IIconCache, IDisposable
         }
     }
 
-    public Task<ImageSource> SourceFromRawSvg(string svgName, string svgValue, double squareSize = 22d, string additionalCacheKey = "", Color colorOverride = default(Color))
+    public Task<ImageSource> SourceFromRawSvg(string svgName, string svgValue, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = null)
     {
         return SourceFromRawSvg(svgName, svgValue, new Size(squareSize, squareSize), additionalCacheKey, colorOverride);
     }
 
-    public async Task<ImageSource> SourceFromRawSvg(string svgName, string svgValue, Size size, string additionalCacheKey = "", Color colorOverride = default(Color))
+    public async Task<ImageSource> SourceFromRawSvg(string svgName, string svgValue, Size size, string additionalCacheKey = "", Color? colorOverride = null)
     {
         try
         {
@@ -127,12 +128,12 @@ public abstract class IconCacheBase : IIconCache, IDisposable
         }
     }
 
-    public Task<FileImageSource> FileImageSourceFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color colorOverride = default(Color))
+    public Task<FileImageSource> FileImageSourceFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = null)
     {
         return FileImageSourceFromSvg(svgName, new Size(squareSize, squareSize), additionalCacheKey, colorOverride);
     }
 
-    public async Task<FileImageSource> FileImageSourceFromSvg(string svgName, Size size, string additionalCacheKey = "", Color colorOverride = default(Color))
+    public async Task<FileImageSource> FileImageSourceFromSvg(string svgName, Size size, string additionalCacheKey = "", Color? colorOverride = null)
     {
         try
         {
@@ -159,6 +160,11 @@ public abstract class IconCacheBase : IIconCache, IDisposable
 
             _resolvedIcons[key] = diskCachedImage;
 
+            if (DeviceInfo.Current.Platform == DevicePlatform.iOS)
+            {
+                return new FileImageSource { File = diskCachedImage };
+            }
+
             return new FileImageSource { File = diskCachedImage };
         }
         catch (Exception ex)
@@ -173,7 +179,7 @@ public abstract class IconCacheBase : IIconCache, IDisposable
         }
     }
 
-    private string GetImagePathFromDiskCache(string key)
+    private string? GetImagePathFromDiskCache(string key)
     {
         if (!Directory.Exists(PlatformInfo.IconCacheDirectory))
         {
@@ -185,6 +191,12 @@ public abstract class IconCacheBase : IIconCache, IDisposable
         if (!File.Exists(filePath))
         {
             return null;
+        }
+
+        if (DeviceInfo.Current.Platform == DevicePlatform.iOS ||
+            DeviceInfo.Current.Platform == DevicePlatform.MacCatalyst)
+        {
+            return $"{filePath.Split('@')[0]}.png";
         }
 
         return filePath;
@@ -201,7 +213,7 @@ public abstract class IconCacheBase : IIconCache, IDisposable
         }
     }
 
-    private async Task GenerateImageFromEmbedded(string key, string svgName, Size size, Color colorOverride)
+    private async Task GenerateImageFromEmbedded(string key, string svgName, Size size, Color? colorOverride = null)
     {
         try
         {
@@ -235,7 +247,7 @@ public abstract class IconCacheBase : IIconCache, IDisposable
         }
     }
 
-    private async Task GenerateImageFromRaw(string key, string svgValue, Size size, Color colorOverride)
+    private async Task GenerateImageFromRaw(string key, string svgValue, Size size, Color? colorOverride = null)
     {
         try
         {
@@ -267,9 +279,11 @@ public abstract class IconCacheBase : IIconCache, IDisposable
         }
     }
 
-    private async Task RenderSvgAsync(SKSvg skSvg, string key, Size size, Color colorOverride)
+    private async Task RenderSvgAsync(SKSvg skSvg, string key, Size size, Color? colorOverride)
     {
-        var scaledCanvas = _platformScalingFactor;
+        var platformScalingFactor = _platformScalingFactor;
+
+        var scaledCanvas = platformScalingFactor;
 
         SKRect resize = skSvg.Picture.CullRect;
 
@@ -277,45 +291,50 @@ public abstract class IconCacheBase : IIconCache, IDisposable
         {
             var minSize = (float)Math.Min(size.Width, size.Height);
 
-            scaledCanvas = (minSize / Math.Max(skSvg.Picture.CullRect.Width, skSvg.Picture.CullRect.Height)) * _platformScalingFactor;
+            scaledCanvas = (float)Math.Round((minSize / Math.Max(skSvg.Picture.CullRect.Width, skSvg.Picture.CullRect.Height)) * platformScalingFactor, 0, MidpointRounding.ToEven);
 
             resize = new SKRect(0, 0, skSvg.Picture.CullRect.Width * scaledCanvas, skSvg.Picture.CullRect.Height * scaledCanvas);
         }
         else if (skSvg.Picture.CullRect != default)
         {
-            resize = new SKRect(0, 0, skSvg.Picture.CullRect.Width * _platformScalingFactor, skSvg.Picture.CullRect.Height * _platformScalingFactor);
+            resize = new SKRect(0, 0, skSvg.Picture.CullRect.Width * platformScalingFactor, skSvg.Picture.CullRect.Height * platformScalingFactor);
         }
 
-        if (colorOverride == default(Color))
+        if (colorOverride == null)
         {
             using var memStream = new MemoryStream();
+
             skSvg.Picture.ToImage(memStream, SKColors.Empty, SKEncodedImageFormat.Png, 100, scaledCanvas, scaledCanvas, SKColorType.Rgba8888, SKAlphaType.Premul, SKColorSpace.CreateSrgb());
+
+            // var img = SKImage.FromPicture(skSvg.Picture, resize.Size.ToSizeI());
+            // using var encoded = img.Encode(SKEncodedImageFormat.Png, 100);
             memStream.Seek(0L, SeekOrigin.Begin);
+
+            // encoded.SaveTo(memStream);
             await SaveIconToDiskCache(key, memStream).ConfigureAwait(false);
             return;
         }
 
-        var imageInfo = new SKImageInfo((int)resize.Width, (int)resize.Height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        var imageInfo = new SKImageInfo((int)Math.Ceiling(resize.Width), (int)Math.Ceiling(resize.Height), SKColorType.Rgba8888, SKAlphaType.Premul);
 
-        using (var bmp = new SKBitmap(imageInfo))
-        using (var canvas = new SKCanvas(bmp))
+        using var bmp = new SKBitmap(imageInfo);
+        using var canvas = new SKCanvas(bmp);
+
+        skSvg.Picture.Draw(SKColor.Empty, scaledCanvas, scaledCanvas, canvas);
+
+        if (colorOverride != default(Color))
         {
-            skSvg.Picture.Draw(SKColor.Empty, scaledCanvas, scaledCanvas, canvas);
+            this._paint.Color = colorOverride.ToSKColor();
+            canvas.DrawPaint(this._paint);
+        }
 
-            if (colorOverride != default(Color))
-            {
-                _paint.Color = colorOverride.ToSKColor();
-                canvas.DrawPaint(_paint);
-            }
+        canvas.Flush();
 
-            canvas.Flush();
-
-            using (var image = SKImage.FromBitmap(bmp))
-            using (var data = image.Encode(SKEncodedImageFormat.Png, 100))
-            using (var stream = data.AsStream(false))
-            {
-                await SaveIconToDiskCache(key, stream).ConfigureAwait(false);
-            }
+        using (var image = SKImage.FromBitmap(bmp))
+        using (var data = image.Encode(SKEncodedImageFormat.Png, 100))
+        using (var stream = data.AsStream(false))
+        {
+            await this.SaveIconToDiskCache(key, stream).ConfigureAwait(false);
         }
     }
 
@@ -352,14 +371,11 @@ public abstract class IconCacheBase : IIconCache, IDisposable
 
     public abstract Task<Stream> StreamFromSource(ImageSource imageSource);
 
-    private string CreateIconKey(string svgName, Size size, string additionalCacheKey = "", Color colorOverride = default(Color))
+    private string CreateIconKey(string svgName, Size size, string additionalCacheKey = "", Color colorOverride = null)
     {
         var key = $"{svgName}_{additionalCacheKey}_{size.Width}_{size.Height}_{colorOverride?.GetHashCode()}".Trim(_underscore);
 
-        if (_platformScalingFactor > 1.01f)
-        {
-            key = $"{key}@{_platformScalingFactor}x";
-        }
+        key = $"{key}@{_platformScalingFactor}x";
 
         key = string.Join(_underscore, key.Split(_invalidFilenameChars));
 
@@ -368,16 +384,16 @@ public abstract class IconCacheBase : IIconCache, IDisposable
 
     protected virtual void Dispose(bool disposing)
     {
-        if (!_disposedValue)
+        if (_disposedValue || !disposing)
         {
-            if (disposing)
-            {
-                _iconLock?.Dispose();
-                _paint.Dispose();
-            }
-
-            _disposedValue = true;
+            return;
         }
+
+        this._iconLock?.Dispose();
+        this._colorspace.Dispose();
+        this._paint.Dispose();
+
+        this._disposedValue = true;
     }
 
     public void Dispose()


### PR DESCRIPTION
- Added a new toolbar item with an SVG icon.
- Introduced a new SVG file for the "more" icon.
- Updated methods to accept nullable color parameters for better flexibility.
- Cleaned up code by removing unused XML imports and optimizing variable usage.
- Enhanced image caching logic for iOS and MacCatalyst platforms.
