### PR TITLE
Add NPicker and update package versions

### DIFF
--- a/AuroraControls.TestApp/AuroraControls.TestApp.csproj
+++ b/AuroraControls.TestApp/AuroraControls.TestApp.csproj
@@ -47,12 +47,13 @@
         <ProjectReference Include="..\AuroraControlsMaui\AuroraControls.Maui.csproj" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="NPicker" Version="2.0.5" />
         <PackageReference Include="ReactiveUI.Maui" Version="20.1.63" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
         <PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
         <PackageReference Include="CommunityToolkit.Maui.Markup" Version="4.1.0" />
         <PackageReference Include="CommunityToolkit.Maui" Version="9.0.3" />
-        <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.90" />
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.90" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.100" />
     </ItemGroup>
 </Project>

--- a/AuroraControls.TestApp/ImageProcessing.xaml.cs
+++ b/AuroraControls.TestApp/ImageProcessing.xaml.cs
@@ -35,12 +35,12 @@ public partial class ImageProcessing : ContentPage
         this._imageProcessing.AddRange([_blur, _circular, _grayscale, _invert, _scale, _sepia]);
     }
 
-    private void Handle_ValueChanged(object sender, ValueChangedEventArgs e)
+    private void Handle_ValueChanged(object? sender, ValueChangedEventArgs e)
     {
         _blur.BlurAmount = e.NewValue;
     }
 
-    private void Handle_Clicked(object sender, System.EventArgs e)
+    private void Handle_Clicked(object? sender, System.EventArgs e)
     {
         if (_index > _imageProcessing.Count - 1)
         {

--- a/AuroraControls.TestApp/MainPage.cs
+++ b/AuroraControls.TestApp/MainPage.cs
@@ -86,6 +86,14 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
                               BorderColor = Colors.Chocolate,
                               BackgroundColor = Colors.Aquamarine,
                             },
+                            new StyledInputLayout
+                            {
+                                Content =
+                                    new NPicker.DatePicker
+                                    {
+                                        Placeholder = "Nullable NDate Picker",
+                                    },
+                            },
                             new Grid
                             {
                                 ColumnDefinitions = Columns.Define(Auto, Star, Auto),

--- a/AuroraControls.TestApp/MauiProgram.cs
+++ b/AuroraControls.TestApp/MauiProgram.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Maui;
 using CommunityToolkit.Maui.Markup;
+using NPicker;
 using SkiaSharp;
 
 namespace AuroraControls.TestApp;
@@ -13,6 +14,28 @@ public static class MauiProgram
             .UseMauiApp<App>()
             .UseMauiCommunityToolkit()
             .UseMauiCommunityToolkitMarkup()
+            .UseNPicker()
+            .ConfigureMauiHandlers(
+                handlers =>
+                {
+                    StyledInputLayout.StyledInputLayoutContentRegistrations
+                        .Add(
+                            typeof(NPicker.DatePicker),
+                            new StyledContentTypeRegistration
+                            {
+                                HasValue =
+                                    view =>
+                                    {
+                                        if (view is NPicker.DatePicker dp)
+                                        {
+                                            return dp.Date.HasValue;
+                                        }
+
+                                        return false;
+                                    },
+                                ValueChangeProperty = nameof(NPicker.DatePicker.Date),
+                            });
+                })
             .ConfigureFonts(
                 fonts =>
                 {

--- a/AuroraControlsMaui/AuroraControls.Maui.csproj
+++ b/AuroraControlsMaui/AuroraControls.Maui.csproj
@@ -4,7 +4,7 @@
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
-        <IsTrimmable>true</IsTrimmable>
+        <Nullable>enable</Nullable>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
@@ -16,12 +16,12 @@
         <CreatePackage>false</CreatePackage>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.8" />
-        <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.8" />
-        <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.8" />
-        <PackageReference Include="Svg.Skia" Version="2.0.0.1" />
+        <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.9" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.9" />
+        <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.9" />
+        <PackageReference Include="Svg.Skia" Version="2.0.0.4" />
         <PackageReference Include="Topten.RichTextKit" Version="0.4.167" />
-        <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.90" />
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.90" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.100" />
     </ItemGroup>
 </Project>

--- a/AuroraControlsMaui/AuroraViewBase.cs
+++ b/AuroraControlsMaui/AuroraViewBase.cs
@@ -59,13 +59,14 @@ public abstract class AuroraViewBase : SKCanvasView, IAuroraView
         PaintSurfaceInternal(e.Surface, e.Info);
     }
 
-    protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
 
-        if (propertyName.Equals(HeightProperty.PropertyName) ||
-            propertyName.Equals(WidthProperty.PropertyName) ||
-            propertyName.Equals(MarginProperty.PropertyName))
+        if (propertyName != null &&
+            (propertyName.Equals(HeightProperty.PropertyName) ||
+                propertyName.Equals(WidthProperty.PropertyName) ||
+                propertyName.Equals(MarginProperty.PropertyName)))
         {
             this.InvalidateSurface();
         }

--- a/AuroraControlsMaui/CupertinoTextToggleSwitch.cs
+++ b/AuroraControlsMaui/CupertinoTextToggleSwitch.cs
@@ -494,22 +494,6 @@ public class CupertinoTextToggleSwitch : AuroraViewBase
         return size;
     }
 
-    public override SizeRequest Measure(double widthConstraint, double heightConstraint, MeasureFlags flags = MeasureFlags.None)
-    {
-        return base.Measure(widthConstraint, heightConstraint, flags);
-    }
-
-    protected override Size ArrangeOverride(Rect bounds)
-    {
-        return base.ArrangeOverride(bounds);
-    }
-
-    protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
-    {
-        var sizeRequest = base.OnMeasure(widthConstraint, heightConstraint);
-        return sizeRequest;
-    }
-
     /// <summary>
     /// SKCanvas method that fires on touch.
     /// </summary>

--- a/AuroraControlsMaui/Effects/ImageProcessingEffect.cs
+++ b/AuroraControlsMaui/Effects/ImageProcessingEffect.cs
@@ -77,7 +77,7 @@ public class ImagePlatformProcessingEffect : PlatformEffect
         }
     }
 
-    private async void ImageProcessingEffects_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs args)
+    private async void ImageProcessingEffects_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs args)
     {
         var view = Control as ImageView;
 
@@ -227,7 +227,7 @@ public class ImagePlatformProcessingEffect : PlatformEffect
         }
     }
 
-    private async void ImageProcessingEffects_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs args)
+    private async void ImageProcessingEffects_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs args)
     {
         var view = Control as UIImageView;
 

--- a/AuroraControlsMaui/Extensions/ImageSourceExtensions.cs
+++ b/AuroraControlsMaui/Extensions/ImageSourceExtensions.cs
@@ -265,14 +265,14 @@ public static class ImageSourceExtensions
         return imageSource;
     }
 
-    public static Button SetSvgIcon(this Button imageElement, string svgName, double squareSize = 22d, Color colorOverride = default(Color))
+    public static Button SetSvgIcon(this Button imageElement, string svgName, double squareSize = 24d, Color? colorOverride = default(Color))
     {
         return IconCache
             .FileImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
             .AsAsyncSourceFor(imageElement);
     }
 
-    public static ImageButton SetSvgIcon(this ImageButton imageButton, string svgName, double squareSize = 22d, Color colorOverride = default(Color))
+    public static ImageButton SetSvgIcon(this ImageButton imageButton, string svgName, double squareSize = 24d, Color colorOverride = default(Color))
     {
         IconCache
             .FileImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
@@ -281,14 +281,14 @@ public static class ImageSourceExtensions
         return imageButton;
     }
 
-    public static ToolbarItem SetSvgIcon(this ToolbarItem toolbarItem, string svgName, double squareSize = 22d, Color colorOverride = default(Color))
+    public static ToolbarItem SetSvgIcon(this ToolbarItem toolbarItem, string svgName, double squareSize = 24d, Color colorOverride = default(Color))
     {
         return IconCache
             .FileImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
             .AsAsyncSourceFor(toolbarItem);
     }
 
-    public static Image SetSvgIcon(this Image image, string svgName, double squareSize = 22d, Color colorOverride = default(Color))
+    public static Image SetSvgIcon(this Image image, string svgName, double squareSize = 24d, Color colorOverride = default(Color))
     {
         return IconCache
             .FileImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)

--- a/AuroraControlsMaui/Extensions/SKCanvasExtensions.cs
+++ b/AuroraControlsMaui/Extensions/SKCanvasExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace AuroraControls;
+﻿using System;
+using System.Collections.Generic;
+
+namespace AuroraControls;
 
 internal static class SKCanvasExtensions
 {

--- a/AuroraControlsMaui/Gauges/CircularFillGauge.cs
+++ b/AuroraControlsMaui/Gauges/CircularFillGauge.cs
@@ -68,7 +68,7 @@ public class CircularFillGauge : AuroraViewBase
     /// The surface is automatically invalidated/redrawn whenever <c>HeightProperty</c>, <c>WidthProperty</c> or <c>MarginProperty</c> gets updated.
     /// </summary>
     /// <param name="propertyName">The name of the bound property that changed.</param>
-    protected override void OnPropertyChanged(string propertyName = null)
+    protected override void OnPropertyChanged(string? propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
 

--- a/AuroraControlsMaui/GlobalUsings.cs
+++ b/AuroraControlsMaui/GlobalUsings.cs
@@ -1,6 +1,9 @@
-﻿global using System.Windows.Input;
+﻿global using System;
+global using System.Threading.Tasks;
+global using System.Windows.Input;
 global using Microsoft.Maui;
 global using Microsoft.Maui.Controls;
+global using Microsoft.Maui.Graphics;
 global using SkiaSharp;
 global using SkiaSharp.Views.Maui;
 global using SkiaSharp.Views.Maui.Controls;

--- a/AuroraControlsMaui/GradientColorView.cs
+++ b/AuroraControlsMaui/GradientColorView.cs
@@ -164,7 +164,7 @@ public class GradientColorView : AuroraViewBase
         base.Attached();
     }
 
-    protected override void OnPropertyChanged(string propertyName = null)
+    protected override void OnPropertyChanged(string? propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
 

--- a/AuroraControlsMaui/IconCacheBase.cs
+++ b/AuroraControlsMaui/IconCacheBase.cs
@@ -291,7 +291,13 @@ public abstract class IconCacheBase : IIconCache, IDisposable
         {
             var minSize = (float)Math.Min(size.Width, size.Height);
 
-            scaledCanvas = (float)Math.Round((minSize / Math.Max(skSvg.Picture.CullRect.Width, skSvg.Picture.CullRect.Height)) * platformScalingFactor, 0, MidpointRounding.ToEven);
+            scaledCanvas = (minSize / Math.Max(skSvg.Picture.CullRect.Width, skSvg.Picture.CullRect.Height)) *
+                           platformScalingFactor;
+
+            if (scaledCanvas > 1.0f)
+            {
+                scaledCanvas = (float)Math.Ceiling(scaledCanvas);
+            }
 
             resize = new SKRect(0, 0, skSvg.Picture.CullRect.Width * scaledCanvas, skSvg.Picture.CullRect.Height * scaledCanvas);
         }

--- a/AuroraControlsMaui/ImageProcessing/ImageProcessingCollection.cs
+++ b/AuroraControlsMaui/ImageProcessing/ImageProcessingCollection.cs
@@ -230,7 +230,7 @@ public class ImageProcessingCollection : BindableObject, IList<ImageProcessingBa
     /// </summary>
     /// <param name="sender">Sender.</param>
     /// <param name="e"><c>PropertyChangedEventArgs</c> provides the <see cref="T:PropertyChangedEventArgs.PropertyName"/> property to get the name of the property that changed.</param>
-    private void HandlePropertyChangedEventHandler(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+    private void HandlePropertyChangedEventHandler(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         ClearValue(Effects.ImageProcessingEffect.ProcessorChangedProperty);
         SetValue(Effects.ImageProcessingEffect.ProcessorChangedProperty, sender);

--- a/AuroraControlsMaui/Loading/MaterialCircular.cs
+++ b/AuroraControlsMaui/Loading/MaterialCircular.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace AuroraControls.Loading;
+﻿namespace AuroraControls.Loading;
 
 /// <summary>
 /// Material circular loading animation.
@@ -9,10 +7,10 @@ namespace AuroraControls.Loading;
 public class MaterialCircular : SceneViewBase
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable
 {
-    private SKPaint _progressPaint;
-    private SKPath _progressPath;
-    private SKPaint _progressBackgroundPaint;
-    private SKPath _backgroundProgressPath;
+    private SKPaint? _progressPaint;
+    private SKPath? _progressPath;
+    private SKPaint? _progressBackgroundPaint;
+    private SKPath? _backgroundProgressPath;
 
     /// <summary>
     /// The foreground color property. Specifies the foreground color.
@@ -35,8 +33,8 @@ public class MaterialCircular : SceneViewBase
     /// <value>Takes a Xamarin.Forms.Color. Default value is default(Xamarin.Forms.Color).</value>
     public Color ForegroundLoadingColor
     {
-        get { return (Color)GetValue(ForegroundLoadingColorProperty); }
-        set { SetValue(ForegroundLoadingColorProperty, value); }
+        get => (Color)GetValue(ForegroundLoadingColorProperty);
+        set => SetValue(ForegroundLoadingColorProperty, value);
     }
 
     /// <summary>
@@ -60,8 +58,8 @@ public class MaterialCircular : SceneViewBase
     /// <value>Takes a Xamarin.Forms.Color. Default value is default(Xamarin.Forms.Color).</value>
     public Color BackgroundLoadingColor
     {
-        get { return (Color)GetValue(BackgroundLoadingColorProperty); }
-        set { SetValue(BackgroundLoadingColorProperty, value); }
+        get => (Color)GetValue(BackgroundLoadingColorProperty);
+        set => SetValue(BackgroundLoadingColorProperty, value);
     }
 
     /// <summary>
@@ -92,8 +90,8 @@ public class MaterialCircular : SceneViewBase
     /// <value>Takes an EndCapType. Default is EndCapType.Rounded.</value>
     public EndCapType EndCapType
     {
-        get { return (EndCapType)GetValue(EndCapTypeProperty); }
-        set { SetValue(EndCapTypeProperty, value); }
+        get => (EndCapType)GetValue(EndCapTypeProperty);
+        set => SetValue(EndCapTypeProperty, value);
     }
 
     /// <summary>
@@ -118,8 +116,8 @@ public class MaterialCircular : SceneViewBase
     /// <value>Takes a double. Default value is 12d.</value>
     public double ProgressThickness
     {
-        get { return (double)GetValue(ProgressThicknessProperty); }
-        set { SetValue(ProgressThicknessProperty, value); }
+        get => (double)GetValue(ProgressThicknessProperty);
+        set => SetValue(ProgressThicknessProperty, value);
     }
 
     public MaterialCircular()
@@ -144,13 +142,13 @@ public class MaterialCircular : SceneViewBase
         _progressPaint.Color = ForegroundLoadingColor.ToSKColor();
         _progressPaint.StrokeWidth = (float)ProgressThickness * _scale;
 
-        _progressPath = new SKPath { };
+        _progressPath = new SKPath();
 
         _progressBackgroundPaint = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Stroke };
         _progressBackgroundPaint.Color = BackgroundLoadingColor.ToSKColor();
         _progressBackgroundPaint.StrokeWidth = (float)ProgressThickness * _scale;
 
-        _backgroundProgressPath = new SKPath { };
+        _backgroundProgressPath = new SKPath();
 
         base.Attached();
     }
@@ -202,19 +200,27 @@ public class MaterialCircular : SceneViewBase
             progressArcLength = 1;
         }
 
-        _backgroundProgressPath.Reset();
-        _backgroundProgressPath.AddArc(arcRect, 0, 360);
+        _backgroundProgressPath?.Reset();
+        _backgroundProgressPath?.AddArc(arcRect, 0, 360);
 
-        _progressPath.Reset();
-        _progressPath.AddArc(arcRect, progressOfCircle, progressArcLength);
+        _progressPath?.Reset();
+        _progressPath?.AddArc(arcRect, progressOfCircle, progressArcLength);
 
         using (new SKAutoCanvasRestore(canvas))
         {
             var matrix = SKMatrix.CreateRotationDegrees(progressOfCircle - 90f, info.Rect.MidX, info.Rect.MidY);
             canvas.SetMatrix(matrix);
             canvas.Clear();
-            canvas.DrawPath(_backgroundProgressPath, _progressBackgroundPaint);
-            canvas.DrawPath(_progressPath, _progressPaint);
+
+            if (this._backgroundProgressPath != null)
+            {
+                canvas.DrawPath(this._backgroundProgressPath, this._progressBackgroundPaint);
+            }
+
+            if (this._progressPath != null)
+            {
+                canvas.DrawPath(this._progressPath, this._progressPaint);
+            }
         }
 
         canvas.Flush();

--- a/AuroraControlsMaui/PlatformUnderlayDrawable.cs
+++ b/AuroraControlsMaui/PlatformUnderlayDrawable.cs
@@ -113,7 +113,7 @@ public class PlatformUnderlayDrawable : IDisposable
         }
     }
 
-    private void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs e)
     {
         if (_virtualView is IUnderlayDrawable ud && _virtualView is Microsoft.Maui.Controls.ContentView cv && cv.Content is not null)
         {
@@ -203,7 +203,7 @@ public class PlatformUnderlayDrawable : IDisposable
         }
     }
 
-    private void Canvas_FocusChange(object sender, Android.Views.View.FocusChangeEventArgs e)
+    private void Canvas_FocusChange(object? sender, Android.Views.View.FocusChangeEventArgs e)
     {
         if (e.HasFocus && _virtualView is Microsoft.Maui.Controls.ContentView cv && cv.Content is IView view)
         {
@@ -211,7 +211,7 @@ public class PlatformUnderlayDrawable : IDisposable
         }
     }
 
-    private void CommandClicked(object sender, EventArgs e)
+    private void CommandClicked(object? sender, EventArgs e)
     {
         if (_virtualView is IUnderlayDrawable ude && (ude.Command?.CanExecute(ude.CommandParameter) ?? false))
         {
@@ -219,7 +219,7 @@ public class PlatformUnderlayDrawable : IDisposable
         }
     }
 
-    private void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs e)
     {
         if (_virtualView is IUnderlayDrawable ud && _virtualView is Microsoft.Maui.Controls.ContentView cv && cv.Content is not null)
         {
@@ -348,8 +348,14 @@ public class PlatformUnderlayDrawable : IDisposable
 
     private static StyledContentTypeRegistration GetRegistration(Type type)
     {
-        foreach (var registration in StyledInputLayout.StyledInputLayoutContentRegistrations)
+        if (StyledInputLayout.StyledInputLayoutContentRegistrations.TryGetValue(type, out var match))
         {
+            return match;
+        }
+
+        for (int i = StyledInputLayout.StyledInputLayoutContentRegistrations.Count - 1; i >= 0; i--)
+        {
+            var registration = StyledInputLayout.StyledInputLayoutContentRegistrations.ElementAt(i);
             if (type.IsAssignableTo(registration.Key))
             {
                 return registration.Value;
@@ -359,7 +365,7 @@ public class PlatformUnderlayDrawable : IDisposable
         return StyledContentTypeRegistration.Default;
     }
 
-    private void Content_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+    private void Content_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         if (_typeRegistration.HasValue && !string.IsNullOrEmpty(_typeRegistration.Value.ValueChangeProperty) && e.PropertyName == _typeRegistration.Value.ValueChangeProperty)
         {

--- a/AuroraControlsMaui/SegmentedControl.cs
+++ b/AuroraControlsMaui/SegmentedControl.cs
@@ -180,7 +180,7 @@ public class SegmentedControl : AuroraViewBase
         base.Detached();
     }
 
-    protected override void OnPropertyChanged(string propertyName = null)
+    protected override void OnPropertyChanged(string? propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
 
@@ -343,6 +343,7 @@ public class SegmentedControl : AuroraViewBase
                                 while (textBounds.Width > 0 && fontPaint.TextSize > 0 && textBounds.Width > segmentSize - borderSize)
                                 {
                                     fontPaint.TextSize--;
+
                                     fontPaint.MeasureText(segment.Text, ref textBounds);
                                 }
 
@@ -414,7 +415,7 @@ public class SegmentedControl : AuroraViewBase
         }
     }
 
-    private void SegmentsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
+    private void SegmentsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs args)
     {
         if (args.OldItems != null)
         {
@@ -435,7 +436,7 @@ public class SegmentedControl : AuroraViewBase
         this.InvalidateSurface();
     }
 
-    private void Item_PropertyChanged(object sender, PropertyChangedEventArgs args)
+    private void Item_PropertyChanged(object? sender, PropertyChangedEventArgs args)
     {
         this.InvalidateSurface();
     }

--- a/AuroraControlsMaui/StyledInputLayoutHandler.cs
+++ b/AuroraControlsMaui/StyledInputLayoutHandler.cs
@@ -17,7 +17,7 @@ public class StyledInputLayoutHandler : ContentViewHandler, IHavePlatformUnderla
     public static PropertyMapper StyledInputLayoutMapper =
         new PropertyMapper<StyledInputLayout, StyledInputLayoutHandler>(ContentViewHandler.Mapper)
         {
-            [nameof(Microsoft.Maui.Controls.ContentView.Content)] = MapStyledInputContent,
+            [nameof(IContentView.Content)] = MapStyledInputContent,
             [nameof(IView.Background)] = MapStyledInputLayoutBackground,
             [nameof(IView.Opacity)] = MapStyledInputLayoutOpacity,
             [nameof(VisualElement.BackgroundColor)] = MapStyledInputLayoutBackground,

--- a/AuroraControlsMaui/Tile.cs
+++ b/AuroraControlsMaui/Tile.cs
@@ -253,8 +253,8 @@ public class Tile : AuroraViewBase
     /// <value>Takes a Xamarin.Forms.Color. Default value is Xamarin.Forms.Color.White.</value>
     public Color FontColor
     {
-        get { return (Color)GetValue(FontColorProperty); }
-        set { SetValue(FontColorProperty, value); }
+        get => (Color)GetValue(FontColorProperty);
+        set => SetValue(FontColorProperty, value);
     }
 
     /// <summary>

--- a/AuroraControlsMaui/UIntTypeConverter.cs
+++ b/AuroraControlsMaui/UIntTypeConverter.cs
@@ -12,18 +12,18 @@ public class UIntTypeConverter : TypeConverter
     public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
             => destinationType == typeof(string);
 
-    public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+    public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
         var strValue = value?.ToString();
         if (string.IsNullOrWhiteSpace(strValue))
         {
-            return null;
+            return 0u;
         }
 
         return uint.Parse(strValue, CultureInfo.InvariantCulture);
     }
 
-    public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+    public override object ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
     {
         if (value is not uint ui)
         {

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -21,7 +21,7 @@
                           Version="8.0.0"
                           PrivateAssets="all" />
         <PackageReference Include="Roslynator.Analyzers"
-                          Version="4.12.6"
+                          Version="4.12.10"
                           PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
- Added NPicker package reference.
- Updated Microsoft.Maui.Controls and Compatibility to version 8.0.100.
- Increased default square size for SVG icons from 22d to 24d in extension methods.
- Made several event handler parameters nullable for better safety.
- Cleaned up unused method overrides in the CupertinoTextToggleSwitch class.
- Improved property change handling across various classes by making parameters nullable.
