### PR TITLE
Refactor styled input layout registration

### DIFF
--- a/AuroraControls.TestApp/MauiProgram.cs
+++ b/AuroraControls.TestApp/MauiProgram.cs
@@ -15,27 +15,7 @@ public static class MauiProgram
             .UseMauiCommunityToolkit()
             .UseMauiCommunityToolkitMarkup()
             .UseNPicker()
-            .ConfigureMauiHandlers(
-                handlers =>
-                {
-                    StyledInputLayout.StyledInputLayoutContentRegistrations
-                        .Add(
-                            typeof(NPicker.DatePicker),
-                            new StyledContentTypeRegistration
-                            {
-                                HasValue =
-                                    view =>
-                                    {
-                                        if (view is NPicker.DatePicker dp)
-                                        {
-                                            return dp.Date.HasValue;
-                                        }
-
-                                        return false;
-                                    },
-                                ValueChangeProperty = nameof(NPicker.DatePicker.Date),
-                            });
-                })
+            .RegisterStyledInputLayout<NPicker.DatePicker>(nameof(NPicker.DatePicker.Date), view => view.Date.HasValue)
             .ConfigureFonts(
                 fonts =>
                 {

--- a/AuroraControlsMaui/AuroraControlBuilder.cs
+++ b/AuroraControlsMaui/AuroraControlBuilder.cs
@@ -49,4 +49,16 @@ public static class AuroraControlBuilder
 
         return mauiAppBuilder;
     }
+
+    public static MauiAppBuilder RegisterStyledInputLayout<TView>(this MauiAppBuilder mauiAppBuilder, string valueChangedPropertyName, Func<TView, bool> hasValue, bool alignPlaceholderToTop = false)
+        where TView : IView
+    {
+        StyledInputLayout
+            .StyledInputLayoutContentRegistrations
+            .Add(
+                typeof(TView),
+                StyledContentTypeRegistration.Build(valueChangedPropertyName, hasValue, alignPlaceholderToTop));
+
+        return mauiAppBuilder;
+    }
 }

--- a/AuroraControlsMaui/PlatformUnderlayDrawable.cs
+++ b/AuroraControlsMaui/PlatformUnderlayDrawable.cs
@@ -367,7 +367,7 @@ public class PlatformUnderlayDrawable : IDisposable
 
     private void Content_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (_typeRegistration.HasValue && !string.IsNullOrEmpty(_typeRegistration.Value.ValueChangeProperty) && e.PropertyName == _typeRegistration.Value.ValueChangeProperty)
+        if (_typeRegistration is not null && !string.IsNullOrEmpty(_typeRegistration.ValueChangeProperty) && e.PropertyName == _typeRegistration.ValueChangeProperty)
         {
             AnimateHasValue();
         }

--- a/AuroraControlsMaui/StyledInputLayout.cs
+++ b/AuroraControlsMaui/StyledInputLayout.cs
@@ -3,56 +3,25 @@
 public class StyledInputLayout : ContentView, IUnderlayDrawable
 {
     public static readonly Dictionary<Type, StyledContentTypeRegistration> StyledInputLayoutContentRegistrations =
-        new Dictionary<Type, StyledContentTypeRegistration>()
+        new()
         {
             [typeof(IPicker)] =
-                new StyledContentTypeRegistration
-                {
-                    HasValue =
-                        view =>
-                        {
-                            if (view is IPicker p)
-                            {
-                                return p.SelectedIndex >= 0;
-                            }
-
-                            return false;
-                        },
-                    ValueChangeProperty = nameof(IPicker.SelectedIndex),
-                },
+                StyledContentTypeRegistration.Build<IPicker>(
+                    nameof(IPicker.SelectedIndex),
+                    view => view.SelectedIndex >= 0,
+                    false),
             [typeof(IDatePicker)] = StyledContentTypeRegistration.Default,
             [typeof(ITimePicker)] = StyledContentTypeRegistration.Default,
             [typeof(Editor)] =
-                new StyledContentTypeRegistration
-                {
-                    AlignPlaceholderToTop = true,
-                    HasValue =
-                        view =>
-                        {
-                            if (view is InputView iv)
-                            {
-                                return !string.IsNullOrEmpty(iv.Text);
-                            }
-
-                            return false;
-                        },
-                    ValueChangeProperty = nameof(Editor.Text),
-                },
+                StyledContentTypeRegistration.Build<Editor>(
+                    nameof(Editor.Text),
+                    view => !string.IsNullOrEmpty(view.Text),
+                    true),
             [typeof(InputView)] =
-                new StyledContentTypeRegistration
-                {
-                    HasValue =
-                        view =>
-                        {
-                            if (view is InputView iv)
-                            {
-                                return !string.IsNullOrEmpty(iv.Text);
-                            }
-
-                            return false;
-                        },
-                    ValueChangeProperty = nameof(InputView.Text),
-                },
+                StyledContentTypeRegistration.Build<InputView>(
+                    nameof(InputView.Text),
+                    view => !string.IsNullOrEmpty(view.Text),
+                    false),
         };
 
     public bool AlignPlaceholderToTop => false;
@@ -234,18 +203,15 @@ public class StyledInputLayout : ContentView, IUnderlayDrawable
     }
 }
 
-public struct StyledContentTypeRegistration
+public record StyledContentTypeRegistration(string ValueChangeProperty, Func<IView, bool> HasValue, bool AlignPlaceholderToTop)
 {
-    public Func<IView, bool> HasValue { get; set; }
-
-    public bool AlignPlaceholderToTop { get; set; }
-
-    public string ValueChangeProperty { get; set; }
-
     public static readonly StyledContentTypeRegistration Default =
-        new StyledContentTypeRegistration
-        {
-            HasValue = _ => true,
-            AlignPlaceholderToTop = false,
-        };
+        new(string.Empty, _ => true, false);
+
+    public static StyledContentTypeRegistration Build<TView>(string valueChangeProperty, Func<TView, bool> hasValue,
+        bool alignPlaceholderToTop)
+    where TView : IView
+    {
+        return new StyledContentTypeRegistration(valueChangeProperty, viewIn => viewIn is TView view && hasValue(view), alignPlaceholderToTop);
+    }
 }


### PR DESCRIPTION
- Simplified the registration of styled input layouts.
- Introduced a new method to register styled input layouts generically.
- Cleaned up property change handling logic for better readability.
- Updated how content type registrations are defined, reducing boilerplate code.
