### PR TITLE
Add command handling to input layouts

### DIFF
--- a/AuroraControls.TestApp/MainPage.cs
+++ b/AuroraControls.TestApp/MainPage.cs
@@ -109,6 +109,15 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
                             },
                             new StyledInputLayout
                             {
+                                Command = new Command(() => this.DisplayAlert("Command Tapped", "You have successfully tapped the command", "Great, Thanks!")),
+                                Content =
+                                    new Entry
+                                    {
+                                        Placeholder = "Styled input layout with command",
+                                    },
+                            },
+                            new StyledInputLayout
+                            {
                                 Placeholder = "Nullable Date Picker",
                                 Content =
                                     new CalendarPicker()

--- a/AuroraControlsMaui/PlatformUnderlayDrawable.cs
+++ b/AuroraControlsMaui/PlatformUnderlayDrawable.cs
@@ -113,46 +113,48 @@ public class PlatformUnderlayDrawable : IDisposable
         }
     }
 
+    public void OnCommandSet()
+    {
+        if (this._virtualView is not IUnderlayDrawable ud)
+        {
+            return;
+        }
+
+        if (ud.Command is not null)
+        {
+            if (this._commandView is null)
+            {
+                this._commandView =
+                    new UIView
+                    {
+                        BackgroundColor = UIColor.Clear,
+                        UserInteractionEnabled = true,
+                        Frame = new CGRect(0f, 0f, (float)this._virtualView.Width, (float)this._virtualView.Height),
+                    };
+                this._commandView.AddGestureRecognizer(
+                    this._commandViewTapped = new UITapGestureRecognizer(() =>
+                    {
+                        if (this._virtualView is IUnderlayDrawable ude && (ude.Command?.CanExecute(ude.CommandParameter) ?? false))
+                        {
+                            ude.Command.Execute(ude.CommandParameter);
+                        }
+                    }));
+            }
+
+            this._platformView.AddSubview(this._commandView);
+            this._platformView.BringSubviewToFront(this._commandView);
+        }
+        else if (ud.Command is null && this._commandView is not null)
+        {
+            this._commandView?.RemoveFromSuperview();
+        }
+    }
+
     private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs e)
     {
         if (_virtualView is IUnderlayDrawable ud && _virtualView is Microsoft.Maui.Controls.ContentView cv && cv.Content is not null)
         {
             DrawUnderlay(ud, cv, cv.Content.Frame, e.Surface, e.Info);
-        }
-    }
-
-    private void OnCommandSet()
-    {
-        if (_virtualView is IUnderlayDrawable ud)
-        {
-            if (ud.Command is not null)
-            {
-                if (_commandView is null)
-                {
-                    _commandView =
-                        new UIView
-                        {
-                            BackgroundColor = UIColor.Clear,
-                            UserInteractionEnabled = true,
-                            Frame = new CGRect(0f, 0f, (float)_virtualView.Width, (float)_virtualView.Height),
-                        };
-                    _commandView.AddGestureRecognizer(
-                        _commandViewTapped = new UITapGestureRecognizer(() =>
-                        {
-                            if (_virtualView is IUnderlayDrawable ude && (ude.Command?.CanExecute(ude.CommandParameter) ?? false))
-                            {
-                                ude.Command.Execute(ude.CommandParameter);
-                            }
-                        }));
-                }
-
-                _platformView.AddSubview(_commandView);
-                _platformView.BringSubviewToFront(_commandView);
-            }
-            else if (ud.Command is null && _commandView is not null)
-            {
-                _commandView?.RemoveFromSuperview();
-            }
         }
     }
 
@@ -166,17 +168,19 @@ public class PlatformUnderlayDrawable : IDisposable
         _platformView = platformView;
         _virtualView = virtualView;
 
-        if (_canvas is null)
+        if (this._canvas is not null)
         {
-            _canvas = new SKCanvasView(platformView.Context);
-
-            _canvas.PaintSurface += OnPaintSurface;
-            _canvas.FocusChange += Canvas_FocusChange;
-            _canvas.Layout(0, 0, platformView.Width, platformView.Height);
-            _canvas.Invalidate();
-
-            Invalidate();
+            return;
         }
+
+        this._canvas = new SKCanvasView(platformView.Context);
+
+        this._canvas.PaintSurface += this.OnPaintSurface;
+        this._canvas.FocusChange += this.Canvas_FocusChange;
+        this._canvas.Layout(0, 0, platformView.Width, platformView.Height);
+        this._canvas.Invalidate();
+
+        this.Invalidate();
     }
 
     public void DisconnectHandler()
@@ -203,6 +207,35 @@ public class PlatformUnderlayDrawable : IDisposable
         }
     }
 
+    public void OnCommandSet()
+    {
+        if (this._virtualView is not IUnderlayDrawable ud)
+        {
+            return;
+        }
+
+        if (ud.Command is not null)
+        {
+            if (this._commandButton is null)
+            {
+                this._commandButton =
+                    new Android.Widget.Button(this._platformView.Context)
+                    {
+                        Background = new ColorDrawable(Android.Graphics.Color.Transparent),
+                    };
+
+                this._commandButton.Click += this.CommandClicked;
+            }
+
+            this._platformView.AddView(this._commandButton);
+            this._commandButton.Layout(0, 0, this._platformView.Width, this._platformView.Height);
+        }
+        else if (ud.Command is null && this._commandButton is not null)
+        {
+            this._commandButton?.RemoveFromParent();
+        }
+    }
+
     private void Canvas_FocusChange(object? sender, Android.Views.View.FocusChangeEventArgs e)
     {
         if (e.HasFocus && _virtualView is Microsoft.Maui.Controls.ContentView cv && cv.Content is IView view)
@@ -226,32 +259,9 @@ public class PlatformUnderlayDrawable : IDisposable
             DrawUnderlay(ud, cv, cv.Content.Frame, e.Surface, e.Info);
         }
     }
-
-    private void OnCommandSet()
+#else
+    public void OnCommandSet()
     {
-        if (_virtualView is IUnderlayDrawable ud)
-        {
-            if (ud.Command is not null)
-            {
-                if (_commandButton is null)
-                {
-                    _commandButton =
-                        new Android.Widget.Button(_platformView.Context)
-                        {
-                            Background = new ColorDrawable(Android.Graphics.Color.Transparent),
-                        };
-
-                    _commandButton.Click += CommandClicked;
-                }
-
-                _platformView.AddView(_commandButton);
-                _commandButton.Layout(0, 0, _platformView.Width, _platformView.Height);
-            }
-            else if (ud.Command is null && _commandButton is not null)
-            {
-                _commandButton?.RemoveFromParent();
-            }
-        }
     }
 #endif
 

--- a/AuroraControlsMaui/StyledInputLayoutHandler.cs
+++ b/AuroraControlsMaui/StyledInputLayoutHandler.cs
@@ -29,6 +29,7 @@ public class StyledInputLayoutHandler : ContentViewHandler, IHavePlatformUnderla
             [nameof(IUnderlayDrawable.InternalMargin)] = MapStyledInputLayoutInternalMargin,
             [nameof(IUnderlayDrawable.FocusAnimationPercentage)] = MapFocusAnimationPercentage,
             [nameof(IUnderlayDrawable.HasValueAnimationPercentage)] = MapHasValueAnimationPercentage,
+            [nameof(IUnderlayDrawable.Command)] = MapCommand,
         };
 
     public bool PreviousHasValue { get; set; }
@@ -85,6 +86,11 @@ public class StyledInputLayoutHandler : ContentViewHandler, IHavePlatformUnderla
     {
         base.UpdateValue(property);
 
+        if (property is nameof(IUnderlayDrawable.Command) or nameof(IUnderlayDrawable.CommandParameter))
+        {
+            this.PlatformUnderlayDrawable?.OnCommandSet();
+        }
+
         this.PlatformUnderlayDrawable?.Invalidate();
     }
 
@@ -140,9 +146,9 @@ public class StyledInputLayoutHandler : ContentViewHandler, IHavePlatformUnderla
         Invalidate(elementHandler, underlayDrawable);
     }
 
-    private static void Invalidate(IContentViewHandler elementHandler, IUnderlayDrawable underlayDrawable)
+    private static void MapCommand(IContentViewHandler elementHandler, IUnderlayDrawable underlayDrawable)
     {
-        (elementHandler as IHavePlatformUnderlayDrawable)?.PlatformUnderlayDrawable?.Invalidate();
+        (elementHandler as IHavePlatformUnderlayDrawable)?.PlatformUnderlayDrawable?.OnCommandSet();
     }
 
     private static void MapStyledInputContent(IContentViewHandler elementHandler, IContentView view)
@@ -163,5 +169,10 @@ public class StyledInputLayoutHandler : ContentViewHandler, IHavePlatformUnderla
 
             inputView.PlaceholderColor = Colors.Transparent;
         }
+    }
+
+    private static void Invalidate(IContentViewHandler elementHandler, IUnderlayDrawable underlayDrawable)
+    {
+        (elementHandler as IHavePlatformUnderlayDrawable)?.PlatformUnderlayDrawable?.Invalidate();
     }
 }


### PR DESCRIPTION
- Implemented a command for the styled input layout that triggers an alert when tapped.
- Enhanced the underlay drawable to manage command execution and button visibility based on command state.
- Updated handlers to call `OnCommandSet` when the command or its parameters change.
- Cleaned up redundant code in the drawing logic for better readability.
