### PR TITLE
Handles null background colors on iOS

### DIFF
--- a/AuroraControlsMaui/Platforms/iOS/RoundedCornersPlatformEffect.cs
+++ b/AuroraControlsMaui/Platforms/iOS/RoundedCornersPlatformEffect.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using CoreGraphics;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Platform;
 using UIKit;
@@ -65,10 +66,10 @@ public class RoundedCornersPlatformEffect : PlatformEffect
         }
 
         view.BackgroundColor = UIColor.Clear;
-        view.Layer.BackgroundColor = ve.BackgroundColor.ToCGColor();
+        view.Layer.BackgroundColor = ve.BackgroundColor?.ToCGColor() ?? UIColor.Clear.CGColor;
         view.Layer.EdgeAntialiasingMask = CoreAnimation.CAEdgeAntialiasingMask.All;
         view.Layer.BorderWidth = (NFloat)Effects.RoundedCornersEffect.GetBorderSize(this.Element);
-        view.Layer.BorderColor = Effects.RoundedCornersEffect.GetBorderColor(this.Element).ToCGColor();
+        view.Layer.BorderColor = Effects.RoundedCornersEffect.GetBorderColor(this.Element)?.ToCGColor() ?? UIColor.Clear.CGColor;
         view.Layer.CornerRadius = (NFloat)Effects.RoundedCornersEffect.GetCornerRadius(this.Element);
     }
 }


### PR DESCRIPTION
Ensures that the background color is properly handled, even when it is null.

Avoids a potential crash by providing a default clear color when the background color or border color is null.
