### PR TITLE
Adds SafeArea effect

### DIFF
--- a/AuroraControls.TestApp/MainPage.cs
+++ b/AuroraControls.TestApp/MainPage.cs
@@ -60,6 +60,8 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
 
     private Button _viewToggleIssueButton;
 
+    private Button _viewSafeAreaTestButton;
+
     private SvgImageView _svgImageView;
 
     private Button _svgImageViewTapped;
@@ -113,6 +115,10 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
                                 .BindClicked(async () =>
                                     await this.Navigation.PushAsync(new ToggleBoxCollectionViewIssuePage()))
                                 .Assign(out _viewToggleIssueButton),
+                            new Button { Text = "View SafeArea Effect Test", }
+                                .BindClicked(async () =>
+                                    await this.Navigation.PushAsync(new SafeAreaTestPage()))
+                                .Assign(out _viewSafeAreaTestButton),
                             new ToggleBox
                             {
                                 ToggledBackgroundColor = Colors.Fuchsia,

--- a/AuroraControls.TestApp/SafeAreaTestPage.xaml
+++ b/AuroraControls.TestApp/SafeAreaTestPage.xaml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:effects="http://auroracontrols.maui/controls"
+             xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
+             x:Class="AuroraControls.TestApp.SafeAreaTestPage"
+             Title="SafeArea Effect Test"
+             ios:Page.UseSafeArea="False">
+    <Grid RowDefinitions="Auto,*,Auto" effects:SafeAreaEffect.SafeArea="false, false, false, false">
+        <ScrollView Grid.Row="1">
+            <VerticalStackLayout Padding="20" Spacing="20">
+                <!-- Header with explanation -->
+                <Label Text="SafeAreaEffect Test"
+                       FontSize="24"
+                       HorizontalOptions="Center" />
+                <Label Text="This page demonstrates different configurations of the SafeAreaEffect. Each frame shows a different configuration of safe area insets."
+                       FontSize="16" />
+
+                <!-- Uniform SafeArea = true -->
+                <Frame BackgroundColor="LightBlue" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Uniform SafeArea = true" FontAttributes="Bold" />
+                        <Label Text="All edges respect safe area" />
+                        <BoxView HeightRequest="80" BackgroundColor="AliceBlue"
+                                 effects:SafeAreaEffect.SafeArea="true" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Uniform SafeArea = false -->
+                <Frame BackgroundColor="LightGreen" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Uniform SafeArea = false" FontAttributes="Bold" />
+                        <Label Text="No edges respect safe area" />
+                        <BoxView HeightRequest="80" BackgroundColor="Honeydew"
+                                 effects:SafeAreaEffect.SafeArea="false" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Horizontal only -->
+                <Frame BackgroundColor="LightYellow" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Horizontal only (true, false)" FontAttributes="Bold" />
+                        <Label Text="Only left and right edges respect safe area" />
+                        <BoxView HeightRequest="80" BackgroundColor="LemonChiffon"
+                                 effects:SafeAreaEffect.SafeArea="true, false" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Vertical only -->
+                <Frame BackgroundColor="LightPink" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Vertical only (false, true)" FontAttributes="Bold" />
+                        <Label Text="Only top and bottom edges respect safe area" />
+                        <BoxView HeightRequest="80" BackgroundColor="MistyRose"
+                                 effects:SafeAreaEffect.SafeArea="false, true" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Custom configuration -->
+                <Frame BackgroundColor="LightSalmon" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Custom (true, true, false, false)" FontAttributes="Bold" />
+                        <Label Text="Left and Top respect safe area, Right and Bottom don't" />
+                        <BoxView HeightRequest="80" BackgroundColor="PeachPuff"
+                                 effects:SafeAreaEffect.SafeArea="true, true, false, false" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Another custom configuration -->
+                <Frame BackgroundColor="Lavender" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Custom (false, false, true, true)" FontAttributes="Bold" />
+                        <Label Text="Right and Bottom respect safe area, Left and Top don't" />
+                        <BoxView HeightRequest="80" BackgroundColor="Thistle"
+                                 effects:SafeAreaEffect.SafeArea="false, false, true, true" />
+                    </VerticalStackLayout>
+                </Frame>
+            </VerticalStackLayout>
+        </ScrollView>
+
+        <!-- Bottom control panel -->
+        <Frame Grid.Row="2" Padding="20" Margin="0" BackgroundColor="WhiteSmoke">
+            <VerticalStackLayout Spacing="10" effects:SafeAreaEffect.SafeArea="false, false, false, true">
+                <Label Text="Note: The effect is most visible on devices with notches or rounded corners" FontSize="14" />
+                <Button Text="Back to Main Page" Clicked="OnBackButtonClicked" />
+            </VerticalStackLayout>
+        </Frame>
+    </Grid>
+</ContentPage>

--- a/AuroraControls.TestApp/SafeAreaTestPage.xaml.cs
+++ b/AuroraControls.TestApp/SafeAreaTestPage.xaml.cs
@@ -1,0 +1,14 @@
+namespace AuroraControls.TestApp;
+
+public partial class SafeAreaTestPage : ContentPage
+{
+    public SafeAreaTestPage()
+    {
+        InitializeComponent();
+    }
+
+    private void OnBackButtonClicked(object sender, EventArgs e)
+    {
+        Navigation.PopAsync();
+    }
+}

--- a/AuroraControlsMaui/AuroraControlBuilder.cs
+++ b/AuroraControlsMaui/AuroraControlBuilder.cs
@@ -33,7 +33,8 @@ public static class AuroraControlBuilder
                     effects
                         .Add<Effects.ImageProcessingEffect, Effects.ImageProcessingPlatformEffect>()
                         .Add<Effects.ShadowEffect, ShadowPlatformEffect>()
-                        .Add<Effects.RoundedCornersEffect, RoundedCornersPlatformEffect>();
+                        .Add<Effects.RoundedCornersEffect, RoundedCornersPlatformEffect>()
+                        .Add<Effects.SafeAreaEffect, SafeAreaPlatformEffect>();
 #endif
                 });
 

--- a/AuroraControlsMaui/Effects/SafeArea.cs
+++ b/AuroraControlsMaui/Effects/SafeArea.cs
@@ -1,0 +1,82 @@
+using System.ComponentModel;
+
+namespace AuroraControls.Effects;
+
+[TypeConverter(typeof(SafeAreaTypeConverter))]
+public struct SafeArea
+{
+    private readonly bool _isParameterized;
+
+    public bool Left { get; }
+
+    public bool Top { get; }
+
+    public bool Right { get; }
+
+    public bool Bottom { get; }
+
+    public bool IsEmpty
+        => !Left && !Top && !Right && !Bottom;
+
+    public SafeArea(bool uniformSafeArea)
+        : this(uniformSafeArea, uniformSafeArea, uniformSafeArea, uniformSafeArea)
+    {
+    }
+
+    public SafeArea(bool horizontal, bool vertical)
+        : this(horizontal, vertical, horizontal, vertical)
+    {
+    }
+
+    public SafeArea(bool left, bool top, bool right, bool bottom)
+    {
+        this._isParameterized = true;
+
+        Left = left;
+        Top = top;
+        Right = right;
+        Bottom = bottom;
+    }
+
+    public static implicit operator SafeArea(bool uniformSafeArea)
+        => new SafeArea(uniformSafeArea);
+
+    private bool Equals(SafeArea other)
+        => (!this._isParameterized &&
+            !other._isParameterized) ||
+           (Left == other.Left &&
+            Top == other.Top &&
+            Right == other.Right &&
+            Bottom == other.Bottom);
+
+    public override bool Equals(object? obj)
+        => obj is not null
+           && obj is SafeArea safeArea
+           && Equals(safeArea);
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Left.GetHashCode();
+            hashCode = (hashCode * 397) ^ Top.GetHashCode();
+            hashCode = (hashCode * 397) ^ Right.GetHashCode();
+            hashCode = (hashCode * 397) ^ Bottom.GetHashCode();
+            return hashCode;
+        }
+    }
+
+    public static bool operator ==(SafeArea left, SafeArea right)
+        => left.Equals(right);
+
+    public static bool operator !=(SafeArea left, SafeArea right)
+        => !left.Equals(right);
+
+    public void Deconstruct(out bool left, out bool top, out bool right, out bool bottom)
+    {
+        left = Left;
+        top = Top;
+        right = Right;
+        bottom = Bottom;
+    }
+}

--- a/AuroraControlsMaui/Effects/SafeAreaEffect.cs
+++ b/AuroraControlsMaui/Effects/SafeAreaEffect.cs
@@ -1,0 +1,36 @@
+namespace AuroraControls.Effects;
+
+public class SafeAreaEffect : RoutingEffect
+{
+    public static readonly BindableProperty SafeAreaProperty =
+        BindableProperty.CreateAttached("SafeArea", typeof(SafeArea), typeof(SafeAreaEffect), default(SafeArea),
+            propertyChanged: OnSafeAreaChanged);
+
+    public static SafeArea GetSafeArea(BindableObject view)
+        => (SafeArea)view.GetValue(SafeAreaProperty);
+
+    public static void SetSafeArea(BindableObject view, SafeArea value)
+        => view.SetValue(SafeAreaProperty, value);
+
+    private static void OnSafeAreaChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (!(bindable is View view))
+        {
+            return;
+        }
+
+        var oldEffect = view.Effects.FirstOrDefault(e => e is SafeAreaEffect);
+
+        if (oldEffect != null)
+        {
+            view.Effects.Remove(oldEffect);
+        }
+
+        if (((SafeArea)newValue).IsEmpty)
+        {
+            return;
+        }
+
+        view.Effects.Add(new SafeAreaEffect());
+    }
+}

--- a/AuroraControlsMaui/Effects/SafeAreaTypeConverter.cs
+++ b/AuroraControlsMaui/Effects/SafeAreaTypeConverter.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel;
+using System.Globalization;
+
+namespace AuroraControls.Effects;
+
+[TypeConverter(typeof(SafeArea))]
+public class SafeAreaTypeConverter : TypeConverter
+{
+    public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+    {
+        var strValue = value.ToString() ?? string.Empty;
+
+        if (strValue != null)
+        {
+            strValue = strValue.Trim();
+
+            if (strValue.Contains(","))
+            {
+                // XAML based definition
+                var safeArea = strValue.Split(',');
+
+                switch (safeArea.Length)
+                {
+                    case 2:
+                        if (bool.TryParse(safeArea[0], out var h)
+                            && bool.TryParse(safeArea[1], out var v))
+                        {
+                            return new SafeArea(h, v);
+                        }
+
+                        break;
+                    case 4:
+                        if (bool.TryParse(safeArea[0], out var l)
+                            && bool.TryParse(safeArea[1], out var t)
+                            && bool.TryParse(safeArea[2], out var r)
+                            && bool.TryParse(safeArea[3], out var b))
+                        {
+                            return new SafeArea(l, t, r, b);
+                        }
+
+                        break;
+                }
+            }
+            else
+            {
+                // Single uniform SafeArea
+                if (bool.TryParse(strValue, out var l))
+                {
+                    return new SafeArea(l);
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(SafeArea)}");
+    }
+}

--- a/AuroraControlsMaui/Platforms/MacCatalyst/SafeAreaPlatformEffect.cs
+++ b/AuroraControlsMaui/Platforms/MacCatalyst/SafeAreaPlatformEffect.cs
@@ -1,0 +1,70 @@
+using AuroraControls.Effects;
+using Foundation;
+using Microsoft.Maui.Controls.Platform;
+using UIKit;
+
+namespace AuroraControls;
+
+public class SafeAreaPlatformEffect : PlatformEffect
+{
+    private Thickness _initialMargin;
+    private NSObject? _orientationDidChangeNotificationObserver;
+
+    private new View Element => (View)base.Element;
+
+    private bool IsEligibleToConsumeEffect
+        => Element != null
+           && UIDevice.CurrentDevice.CheckSystemVersion(11, 0)
+           && UIApplication.SharedApplication.Windows.Any();
+
+    protected override void OnAttached()
+    {
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        this._orientationDidChangeNotificationObserver = NSNotificationCenter.DefaultCenter.AddObserver(
+            UIDevice.OrientationDidChangeNotification, _ => UpdateInsets());
+
+        this._initialMargin = Element.Margin;
+        UpdateInsets();
+    }
+
+    protected override void OnDetached()
+    {
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        if (this._orientationDidChangeNotificationObserver != null)
+        {
+            NSNotificationCenter.DefaultCenter.RemoveObserver(this._orientationDidChangeNotificationObserver);
+            this._orientationDidChangeNotificationObserver?.Dispose();
+            this._orientationDidChangeNotificationObserver = null;
+        }
+
+        Element.Margin = this._initialMargin;
+    }
+
+    private void UpdateInsets()
+    {
+        // Double-check eligability something might've changed in regard to the windows
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        var insets = UIApplication.SharedApplication.Windows[0].SafeAreaInsets;
+        var safeArea = SafeAreaEffect.GetSafeArea(Element);
+
+        Element.Margin = new Thickness(
+            this._initialMargin.Left + CalculateInsets(insets.Left, safeArea.Left),
+            this._initialMargin.Top + CalculateInsets(insets.Top, safeArea.Top),
+            this._initialMargin.Right + CalculateInsets(insets.Right, safeArea.Right),
+            this._initialMargin.Bottom + CalculateInsets(insets.Bottom, safeArea.Bottom));
+    }
+
+    private double CalculateInsets(double insetsComponent, bool shouldUseInsetsComponent) => shouldUseInsetsComponent ? insetsComponent : 0;
+}

--- a/AuroraControlsMaui/Platforms/iOS/SafeAreaPlatformEffect.cs
+++ b/AuroraControlsMaui/Platforms/iOS/SafeAreaPlatformEffect.cs
@@ -1,0 +1,70 @@
+using AuroraControls.Effects;
+using Foundation;
+using Microsoft.Maui.Controls.Platform;
+using UIKit;
+
+namespace AuroraControls;
+
+public class SafeAreaPlatformEffect : PlatformEffect
+{
+    private Thickness _initialMargin;
+    private NSObject? _orientationDidChangeNotificationObserver;
+
+    private new View Element => (View)base.Element;
+
+    private bool IsEligibleToConsumeEffect
+        => Element != null
+           && UIDevice.CurrentDevice.CheckSystemVersion(11, 0)
+           && UIApplication.SharedApplication.Windows.Any();
+
+    protected override void OnAttached()
+    {
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        this._orientationDidChangeNotificationObserver = NSNotificationCenter.DefaultCenter.AddObserver(
+            UIDevice.OrientationDidChangeNotification, _ => UpdateInsets());
+
+        this._initialMargin = Element.Margin;
+        UpdateInsets();
+    }
+
+    protected override void OnDetached()
+    {
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        if (this._orientationDidChangeNotificationObserver != null)
+        {
+            NSNotificationCenter.DefaultCenter.RemoveObserver(this._orientationDidChangeNotificationObserver);
+            this._orientationDidChangeNotificationObserver?.Dispose();
+            this._orientationDidChangeNotificationObserver = null;
+        }
+
+        Element.Margin = this._initialMargin;
+    }
+
+    private void UpdateInsets()
+    {
+        // Double-check eligability something might've changed in regard to the windows
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        var insets = UIApplication.SharedApplication.Windows[0].SafeAreaInsets;
+        var safeArea = SafeAreaEffect.GetSafeArea(Element);
+
+        Element.Margin = new Thickness(
+            this._initialMargin.Left + CalculateInsets(insets.Left, safeArea.Left),
+            this._initialMargin.Top + CalculateInsets(insets.Top, safeArea.Top),
+            this._initialMargin.Right + CalculateInsets(insets.Right, safeArea.Right),
+            this._initialMargin.Bottom + CalculateInsets(insets.Bottom, safeArea.Bottom));
+    }
+
+    private double CalculateInsets(double insetsComponent, bool shouldUseInsetsComponent) => shouldUseInsetsComponent ? insetsComponent : 0;
+}


### PR DESCRIPTION
Introduces a new effect that allows control over how elements respect the safe area insets on iOS and MacCatalyst.

*   Adds a `SafeAreaEffect` that can be applied to views.
*   Adds a `SafeArea` struct to represent safe area configurations (left, top, right, bottom).
*   Implements platform-specific effects for iOS and MacCatalyst to adjust element margins based on safe area insets.
*   Adds a test page demonstrating various `SafeAreaEffect` configurations.
