### PR TITLE
Extends ChipGroup with scrolling capabilities

### DIFF
--- a/AuroraControls.TestApp/ChipGroupPage.xaml
+++ b/AuroraControls.TestApp/ChipGroupPage.xaml
@@ -4,6 +4,7 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:aurora="http://auroracontrols.maui/controls"
+    xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
     xmlns:local="clr-namespace:AuroraControls.TestApp"
     xmlns:vm="clr-namespace:AuroraControls.TestApp.ViewModels"
     Title="Chip Group Demo"
@@ -17,7 +18,8 @@
         <DataTemplate x:Key="ChipTemplate">
             <aurora:Chip
                 Text="{Binding Name}"
-                LeadingEmbeddedImageName="{Binding IconSource}" />
+                LeadingEmbeddedImageName="{Binding IconSource}"
+                Value="{Binding Name}"/>
         </DataTemplate>
     </ContentPage.Resources>
 
@@ -43,7 +45,7 @@
             Grid.Row="1"
             Margin="0,0,0,20"
             ColumnDefinitions="*,*"
-            RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto"
+            RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
             ColumnSpacing="10"
             RowSpacing="10">
 
@@ -109,15 +111,47 @@
                 Text="Remove All"
                 Clicked="OnClearChipsClicked" />
 
-            <Label
+            <Button
                 Grid.Row="5"
+                Grid.Column="0"
+                Text="Scroll to Random"
+                Clicked="OnScrollToRandomClicked" />
+
+            <Button
+                Grid.Row="5"
+                Grid.Column="1"
+                Text="Scroll to Selection"
+                Clicked="OnScrollToSelectionClicked" />
+
+            <Label
+                Grid.Row="6"
+                Grid.Column="0"
+                Text="Scroll to Value:"
+                VerticalOptions="Center" />
+
+            <HorizontalStackLayout
+                Grid.Row="6"
+                Grid.Column="1"
+                Spacing="8">
+                <Picker
+                    x:Name="ValuePicker"
+                    WidthRequest="120"
+                    ItemsSource="{Binding ChipNames}" />
+                <Button
+                    Text="Go"
+                    WidthRequest="40"
+                    Clicked="OnScrollToValueClicked" />
+            </HorizontalStackLayout>
+
+            <Label
+                Grid.Row="7"
                 Grid.Column="0"
                 Grid.ColumnSpan="2"
                 Text="Selected Chips:"
                 Margin="0,10,0,0" />
 
             <Label
-                Grid.Row="6"
+                Grid.Row="8"
                 Grid.Column="0"
                 Grid.ColumnSpan="2"
                 Text="{Binding SelectedChipsText}"

--- a/AuroraControls.TestApp/ChipGroupPage.xaml.cs
+++ b/AuroraControls.TestApp/ChipGroupPage.xaml.cs
@@ -60,6 +60,87 @@ public partial class ChipGroupPage : ContentPage
         }
     }
 
+    private void OnScrollToRandomClicked(object sender, EventArgs e)
+    {
+        if (ChipGroupSample != null && ChipGroupSample.Chips.Count > 0)
+        {
+            // Get a random chip from the collection
+            int randomIndex = _random.Next(ChipGroupSample.Chips.Count);
+            var randomChip = ChipGroupSample.Chips[randomIndex];
+
+            // Scroll to the random chip
+            bool success = ChipGroupSample.ScrollToChip(randomChip, ScrollToPosition.Center);
+
+            // Provide visual feedback to the user
+            if (success)
+            {
+                // Briefly toggle the chip to provide visual feedback
+                randomChip.IsToggled = true;
+
+                // Create a timer to untoggle the chip after a short delay if it's not meant to stay selected
+                if (!randomChip.IsToggled)
+                {
+                    var timer = Application.Current.Dispatcher.CreateTimer();
+                    timer.Interval = TimeSpan.FromMilliseconds(500);
+                    timer.Tick += (s, args) =>
+                    {
+                        randomChip.IsToggled = false;
+                        timer.Stop();
+                    };
+                    timer.Start();
+                }
+            }
+            else
+            {
+                DisplayAlert("Scrolling Failed", "Could not scroll to the selected chip. Make sure the ChipGroup is in scrollable mode.", "OK");
+            }
+        }
+        else
+        {
+            DisplayAlert("No Chips", "There are no chips to scroll to. Please add some chips first.", "OK");
+        }
+    }
+
+    private void OnScrollToSelectionClicked(object sender, EventArgs e)
+    {
+        if (ChipGroupSample != null)
+        {
+            bool success = ChipGroupSample.ScrollToSelectedChip(ScrollToPosition.Center);
+
+            if (!success)
+            {
+                // Try to scroll to any selected chip if in multi-selection mode
+                if (ChipGroupSample.AllowMultipleSelection && ChipGroupSample.SelectedChips.Count > 0)
+                {
+                    // Scroll to the first selected chip
+                    success = ChipGroupSample.ScrollToChip(ChipGroupSample.SelectedChips[0], ScrollToPosition.MakeVisible);
+                }
+
+                if (!success)
+                {
+                    DisplayAlert("Scrolling Failed", "No selected chip to scroll to, or the ChipGroup is not in scrollable mode.", "OK");
+                }
+            }
+        }
+    }
+
+    private void OnScrollToValueClicked(object sender, EventArgs e)
+    {
+        if (ValuePicker.SelectedItem is string selectedValue && !string.IsNullOrEmpty(selectedValue))
+        {
+            bool success = ChipGroupSample.ScrollToChipWithValue(selectedValue, ScrollToPosition.Center, true, StringComparer.OrdinalIgnoreCase);
+
+            if (!success)
+            {
+                DisplayAlert("Scrolling Failed", $"Could not find a chip with value '{selectedValue}' or the ChipGroup is not in scrollable mode.", "OK");
+            }
+        }
+        else
+        {
+            DisplayAlert("No Value Selected", "Please select a value from the dropdown first.", "OK");
+        }
+    }
+
     private void OnChipSelectionChanged(object sender, ChipSelectionChangedEventArgs e)
     {
         if (BindingContext is ChipGroupViewModel viewModel)

--- a/AuroraControls.TestApp/MainPage.cs
+++ b/AuroraControls.TestApp/MainPage.cs
@@ -60,6 +60,8 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
 
     private Button _viewToggleIssueButton;
 
+    private Button _viewSafeAreaTestButton;
+
     private SvgImageView _svgImageView;
 
     private Button _svgImageViewTapped;
@@ -113,6 +115,10 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
                                 .BindClicked(async () =>
                                     await this.Navigation.PushAsync(new ToggleBoxCollectionViewIssuePage()))
                                 .Assign(out _viewToggleIssueButton),
+                            new Button { Text = "View SafeArea Effect Test", }
+                                .BindClicked(async () =>
+                                    await this.Navigation.PushAsync(new SafeAreaTestPage()))
+                                .Assign(out _viewSafeAreaTestButton),
                             new ToggleBox
                             {
                                 ToggledBackgroundColor = Colors.Fuchsia,

--- a/AuroraControls.TestApp/SafeAreaTestPage.xaml
+++ b/AuroraControls.TestApp/SafeAreaTestPage.xaml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:effects="http://auroracontrols.maui/controls"
+             xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
+             x:Class="AuroraControls.TestApp.SafeAreaTestPage"
+             Title="SafeArea Effect Test"
+             ios:Page.UseSafeArea="False">
+    <Grid RowDefinitions="Auto,*,Auto" effects:SafeAreaEffect.SafeArea="false, false, false, false">
+        <ScrollView Grid.Row="1">
+            <VerticalStackLayout Padding="20" Spacing="20">
+                <!-- Header with explanation -->
+                <Label Text="SafeAreaEffect Test"
+                       FontSize="24"
+                       HorizontalOptions="Center" />
+                <Label Text="This page demonstrates different configurations of the SafeAreaEffect. Each frame shows a different configuration of safe area insets."
+                       FontSize="16" />
+
+                <!-- Uniform SafeArea = true -->
+                <Frame BackgroundColor="LightBlue" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Uniform SafeArea = true" FontAttributes="Bold" />
+                        <Label Text="All edges respect safe area" />
+                        <BoxView HeightRequest="80" BackgroundColor="AliceBlue"
+                                 effects:SafeAreaEffect.SafeArea="true" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Uniform SafeArea = false -->
+                <Frame BackgroundColor="LightGreen" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Uniform SafeArea = false" FontAttributes="Bold" />
+                        <Label Text="No edges respect safe area" />
+                        <BoxView HeightRequest="80" BackgroundColor="Honeydew"
+                                 effects:SafeAreaEffect.SafeArea="false" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Horizontal only -->
+                <Frame BackgroundColor="LightYellow" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Horizontal only (true, false)" FontAttributes="Bold" />
+                        <Label Text="Only left and right edges respect safe area" />
+                        <BoxView HeightRequest="80" BackgroundColor="LemonChiffon"
+                                 effects:SafeAreaEffect.SafeArea="true, false" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Vertical only -->
+                <Frame BackgroundColor="LightPink" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Vertical only (false, true)" FontAttributes="Bold" />
+                        <Label Text="Only top and bottom edges respect safe area" />
+                        <BoxView HeightRequest="80" BackgroundColor="MistyRose"
+                                 effects:SafeAreaEffect.SafeArea="false, true" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Custom configuration -->
+                <Frame BackgroundColor="LightSalmon" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Custom (true, true, false, false)" FontAttributes="Bold" />
+                        <Label Text="Left and Top respect safe area, Right and Bottom don't" />
+                        <BoxView HeightRequest="80" BackgroundColor="PeachPuff"
+                                 effects:SafeAreaEffect.SafeArea="true, true, false, false" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <!-- Another custom configuration -->
+                <Frame BackgroundColor="Lavender" Padding="20">
+                    <VerticalStackLayout>
+                        <Label Text="Custom (false, false, true, true)" FontAttributes="Bold" />
+                        <Label Text="Right and Bottom respect safe area, Left and Top don't" />
+                        <BoxView HeightRequest="80" BackgroundColor="Thistle"
+                                 effects:SafeAreaEffect.SafeArea="false, false, true, true" />
+                    </VerticalStackLayout>
+                </Frame>
+            </VerticalStackLayout>
+        </ScrollView>
+
+        <!-- Bottom control panel -->
+        <Frame Grid.Row="2" Padding="20" Margin="0" BackgroundColor="WhiteSmoke">
+            <VerticalStackLayout Spacing="10" effects:SafeAreaEffect.SafeArea="false, false, false, true">
+                <Label Text="Note: The effect is most visible on devices with notches or rounded corners" FontSize="14" />
+                <Button Text="Back to Main Page" Clicked="OnBackButtonClicked" />
+            </VerticalStackLayout>
+        </Frame>
+    </Grid>
+</ContentPage>

--- a/AuroraControls.TestApp/SafeAreaTestPage.xaml.cs
+++ b/AuroraControls.TestApp/SafeAreaTestPage.xaml.cs
@@ -1,0 +1,14 @@
+namespace AuroraControls.TestApp;
+
+public partial class SafeAreaTestPage : ContentPage
+{
+    public SafeAreaTestPage()
+    {
+        InitializeComponent();
+    }
+
+    private void OnBackButtonClicked(object sender, EventArgs e)
+    {
+        Navigation.PopAsync();
+    }
+}

--- a/AuroraControls.TestApp/ViewModels/ChipGroupViewModel.cs
+++ b/AuroraControls.TestApp/ViewModels/ChipGroupViewModel.cs
@@ -65,8 +65,16 @@ public partial class ChipGroupViewModel : ObservableObject
 
     public string SelectedSelectionMode => AllowMultipleSelection ? "Multiple Selection" : "Single Selection";
 
+    public ObservableCollection<string> ChipNames { get; } = new();
+
     public ChipGroupViewModel()
     {
+        // Populate the ChipNames collection
+        foreach (var name in _chipNames)
+        {
+            ChipNames.Add(name);
+        }
+
         // Add some initial chips
         for (int i = 0; i < 8; i++)
         {
@@ -76,9 +84,12 @@ public partial class ChipGroupViewModel : ObservableObject
 
     public void AddRandomChip()
     {
+        string name = _chipNames[_random.Next(_chipNames.Length)];
+
         var chip = new ChipItemViewModel
         {
-            Name = _chipNames[_random.Next(_chipNames.Length)],
+            Name = name,
+            Value = name, // Set the Value property to match the Name for demonstration purposes
             IconSource = _icons[_random.Next(_icons.Length)],
             IsClosable = _random.Next(2) == 0,
             BackgroundColor = _colors[_random.Next(_colors.Length)],
@@ -91,6 +102,16 @@ public partial class ChipGroupViewModel : ObservableObject
     {
         ChipItems.Clear();
         SelectedChipsText = "None";
+    }
+
+    /// <summary>
+    /// Find a chip item by its value.
+    /// </summary>
+    /// <param name="value">The value to search for.</param>
+    /// <returns>The matching chip item or null if not found.</returns>
+    public ChipItemViewModel GetChipByValue(string value)
+    {
+        return ChipItems.FirstOrDefault(c => string.Equals(c.Value, value, StringComparison.OrdinalIgnoreCase));
     }
 }
 
@@ -107,4 +128,7 @@ public partial class ChipItemViewModel : ObservableObject
 
     [ObservableProperty]
     private string _backgroundColor;
+
+    [ObservableProperty]
+    private string _value;
 }

--- a/AuroraControlsMaui/AuroraControlBuilder.cs
+++ b/AuroraControlsMaui/AuroraControlBuilder.cs
@@ -33,7 +33,8 @@ public static class AuroraControlBuilder
                     effects
                         .Add<Effects.ImageProcessingEffect, Effects.ImageProcessingPlatformEffect>()
                         .Add<Effects.ShadowEffect, ShadowPlatformEffect>()
-                        .Add<Effects.RoundedCornersEffect, RoundedCornersPlatformEffect>();
+                        .Add<Effects.RoundedCornersEffect, RoundedCornersPlatformEffect>()
+                        .Add<Effects.SafeAreaEffect, SafeAreaPlatformEffect>();
 #endif
                 });
 

--- a/AuroraControlsMaui/Effects/SafeArea.cs
+++ b/AuroraControlsMaui/Effects/SafeArea.cs
@@ -1,0 +1,82 @@
+using System.ComponentModel;
+
+namespace AuroraControls.Effects;
+
+[TypeConverter(typeof(SafeAreaTypeConverter))]
+public struct SafeArea
+{
+    private readonly bool _isParameterized;
+
+    public bool Left { get; }
+
+    public bool Top { get; }
+
+    public bool Right { get; }
+
+    public bool Bottom { get; }
+
+    public bool IsEmpty
+        => !Left && !Top && !Right && !Bottom;
+
+    public SafeArea(bool uniformSafeArea)
+        : this(uniformSafeArea, uniformSafeArea, uniformSafeArea, uniformSafeArea)
+    {
+    }
+
+    public SafeArea(bool horizontal, bool vertical)
+        : this(horizontal, vertical, horizontal, vertical)
+    {
+    }
+
+    public SafeArea(bool left, bool top, bool right, bool bottom)
+    {
+        this._isParameterized = true;
+
+        Left = left;
+        Top = top;
+        Right = right;
+        Bottom = bottom;
+    }
+
+    public static implicit operator SafeArea(bool uniformSafeArea)
+        => new SafeArea(uniformSafeArea);
+
+    private bool Equals(SafeArea other)
+        => (!this._isParameterized &&
+            !other._isParameterized) ||
+           (Left == other.Left &&
+            Top == other.Top &&
+            Right == other.Right &&
+            Bottom == other.Bottom);
+
+    public override bool Equals(object? obj)
+        => obj is not null
+           && obj is SafeArea safeArea
+           && Equals(safeArea);
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Left.GetHashCode();
+            hashCode = (hashCode * 397) ^ Top.GetHashCode();
+            hashCode = (hashCode * 397) ^ Right.GetHashCode();
+            hashCode = (hashCode * 397) ^ Bottom.GetHashCode();
+            return hashCode;
+        }
+    }
+
+    public static bool operator ==(SafeArea left, SafeArea right)
+        => left.Equals(right);
+
+    public static bool operator !=(SafeArea left, SafeArea right)
+        => !left.Equals(right);
+
+    public void Deconstruct(out bool left, out bool top, out bool right, out bool bottom)
+    {
+        left = Left;
+        top = Top;
+        right = Right;
+        bottom = Bottom;
+    }
+}

--- a/AuroraControlsMaui/Effects/SafeAreaEffect.cs
+++ b/AuroraControlsMaui/Effects/SafeAreaEffect.cs
@@ -1,0 +1,36 @@
+namespace AuroraControls.Effects;
+
+public class SafeAreaEffect : RoutingEffect
+{
+    public static readonly BindableProperty SafeAreaProperty =
+        BindableProperty.CreateAttached("SafeArea", typeof(SafeArea), typeof(SafeAreaEffect), default(SafeArea),
+            propertyChanged: OnSafeAreaChanged);
+
+    public static SafeArea GetSafeArea(BindableObject view)
+        => (SafeArea)view.GetValue(SafeAreaProperty);
+
+    public static void SetSafeArea(BindableObject view, SafeArea value)
+        => view.SetValue(SafeAreaProperty, value);
+
+    private static void OnSafeAreaChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (!(bindable is View view))
+        {
+            return;
+        }
+
+        var oldEffect = view.Effects.FirstOrDefault(e => e is SafeAreaEffect);
+
+        if (oldEffect != null)
+        {
+            view.Effects.Remove(oldEffect);
+        }
+
+        if (((SafeArea)newValue).IsEmpty)
+        {
+            return;
+        }
+
+        view.Effects.Add(new SafeAreaEffect());
+    }
+}

--- a/AuroraControlsMaui/Effects/SafeAreaTypeConverter.cs
+++ b/AuroraControlsMaui/Effects/SafeAreaTypeConverter.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel;
+using System.Globalization;
+
+namespace AuroraControls.Effects;
+
+[TypeConverter(typeof(SafeArea))]
+public class SafeAreaTypeConverter : TypeConverter
+{
+    public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+    {
+        var strValue = value.ToString() ?? string.Empty;
+
+        if (strValue != null)
+        {
+            strValue = strValue.Trim();
+
+            if (strValue.Contains(","))
+            {
+                // XAML based definition
+                var safeArea = strValue.Split(',');
+
+                switch (safeArea.Length)
+                {
+                    case 2:
+                        if (bool.TryParse(safeArea[0], out var h)
+                            && bool.TryParse(safeArea[1], out var v))
+                        {
+                            return new SafeArea(h, v);
+                        }
+
+                        break;
+                    case 4:
+                        if (bool.TryParse(safeArea[0], out var l)
+                            && bool.TryParse(safeArea[1], out var t)
+                            && bool.TryParse(safeArea[2], out var r)
+                            && bool.TryParse(safeArea[3], out var b))
+                        {
+                            return new SafeArea(l, t, r, b);
+                        }
+
+                        break;
+                }
+            }
+            else
+            {
+                // Single uniform SafeArea
+                if (bool.TryParse(strValue, out var l))
+                {
+                    return new SafeArea(l);
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(SafeArea)}");
+    }
+}

--- a/AuroraControlsMaui/Platforms/MacCatalyst/SafeAreaPlatformEffect.cs
+++ b/AuroraControlsMaui/Platforms/MacCatalyst/SafeAreaPlatformEffect.cs
@@ -1,0 +1,70 @@
+using AuroraControls.Effects;
+using Foundation;
+using Microsoft.Maui.Controls.Platform;
+using UIKit;
+
+namespace AuroraControls;
+
+public class SafeAreaPlatformEffect : PlatformEffect
+{
+    private Thickness _initialMargin;
+    private NSObject? _orientationDidChangeNotificationObserver;
+
+    private new View Element => (View)base.Element;
+
+    private bool IsEligibleToConsumeEffect
+        => Element != null
+           && UIDevice.CurrentDevice.CheckSystemVersion(11, 0)
+           && UIApplication.SharedApplication.Windows.Any();
+
+    protected override void OnAttached()
+    {
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        this._orientationDidChangeNotificationObserver = NSNotificationCenter.DefaultCenter.AddObserver(
+            UIDevice.OrientationDidChangeNotification, _ => UpdateInsets());
+
+        this._initialMargin = Element.Margin;
+        UpdateInsets();
+    }
+
+    protected override void OnDetached()
+    {
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        if (this._orientationDidChangeNotificationObserver != null)
+        {
+            NSNotificationCenter.DefaultCenter.RemoveObserver(this._orientationDidChangeNotificationObserver);
+            this._orientationDidChangeNotificationObserver?.Dispose();
+            this._orientationDidChangeNotificationObserver = null;
+        }
+
+        Element.Margin = this._initialMargin;
+    }
+
+    private void UpdateInsets()
+    {
+        // Double-check eligability something might've changed in regard to the windows
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        var insets = UIApplication.SharedApplication.Windows[0].SafeAreaInsets;
+        var safeArea = SafeAreaEffect.GetSafeArea(Element);
+
+        Element.Margin = new Thickness(
+            this._initialMargin.Left + CalculateInsets(insets.Left, safeArea.Left),
+            this._initialMargin.Top + CalculateInsets(insets.Top, safeArea.Top),
+            this._initialMargin.Right + CalculateInsets(insets.Right, safeArea.Right),
+            this._initialMargin.Bottom + CalculateInsets(insets.Bottom, safeArea.Bottom));
+    }
+
+    private double CalculateInsets(double insetsComponent, bool shouldUseInsetsComponent) => shouldUseInsetsComponent ? insetsComponent : 0;
+}

--- a/AuroraControlsMaui/Platforms/iOS/SafeAreaPlatformEffect.cs
+++ b/AuroraControlsMaui/Platforms/iOS/SafeAreaPlatformEffect.cs
@@ -1,0 +1,70 @@
+using AuroraControls.Effects;
+using Foundation;
+using Microsoft.Maui.Controls.Platform;
+using UIKit;
+
+namespace AuroraControls;
+
+public class SafeAreaPlatformEffect : PlatformEffect
+{
+    private Thickness _initialMargin;
+    private NSObject? _orientationDidChangeNotificationObserver;
+
+    private new View Element => (View)base.Element;
+
+    private bool IsEligibleToConsumeEffect
+        => Element != null
+           && UIDevice.CurrentDevice.CheckSystemVersion(11, 0)
+           && UIApplication.SharedApplication.Windows.Any();
+
+    protected override void OnAttached()
+    {
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        this._orientationDidChangeNotificationObserver = NSNotificationCenter.DefaultCenter.AddObserver(
+            UIDevice.OrientationDidChangeNotification, _ => UpdateInsets());
+
+        this._initialMargin = Element.Margin;
+        UpdateInsets();
+    }
+
+    protected override void OnDetached()
+    {
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        if (this._orientationDidChangeNotificationObserver != null)
+        {
+            NSNotificationCenter.DefaultCenter.RemoveObserver(this._orientationDidChangeNotificationObserver);
+            this._orientationDidChangeNotificationObserver?.Dispose();
+            this._orientationDidChangeNotificationObserver = null;
+        }
+
+        Element.Margin = this._initialMargin;
+    }
+
+    private void UpdateInsets()
+    {
+        // Double-check eligability something might've changed in regard to the windows
+        if (!IsEligibleToConsumeEffect)
+        {
+            return;
+        }
+
+        var insets = UIApplication.SharedApplication.Windows[0].SafeAreaInsets;
+        var safeArea = SafeAreaEffect.GetSafeArea(Element);
+
+        Element.Margin = new Thickness(
+            this._initialMargin.Left + CalculateInsets(insets.Left, safeArea.Left),
+            this._initialMargin.Top + CalculateInsets(insets.Top, safeArea.Top),
+            this._initialMargin.Right + CalculateInsets(insets.Right, safeArea.Right),
+            this._initialMargin.Bottom + CalculateInsets(insets.Bottom, safeArea.Bottom));
+    }
+
+    private double CalculateInsets(double insetsComponent, bool shouldUseInsetsComponent) => shouldUseInsetsComponent ? insetsComponent : 0;
+}

--- a/AuroraControlsMaui/SignaturePad.cs
+++ b/AuroraControlsMaui/SignaturePad.cs
@@ -232,12 +232,12 @@ public class SignaturePad : AuroraViewBase
     /// Gets a bitmap of the signature with a white background.
     /// </summary>
     /// <returns>A bitmap of the signature.</returns>
-    public SKBitmap GetSignatureBitmap()
+    public SKBitmap GetSignatureBitmap(Color? backgroundColor = null)
     {
         var bitmap = new SKBitmap((int)CanvasSize.Width, (int)CanvasSize.Height);
 
         using var canvas = new SKCanvas(bitmap);
-        canvas.Clear(SKColors.White);
+        canvas.Clear((backgroundColor ?? Colors.White).ToSKColor());
 
         using var paint = new SKPaint
         {
@@ -257,6 +257,13 @@ public class SignaturePad : AuroraViewBase
         }
 
         return bitmap;
+    }
+
+    public Stream GetSignatureImageStream(SKEncodedImageFormat format, int quality = 100, Color? backgroundColor = null)
+    {
+        using var imageBitmap = GetSignatureBitmap(backgroundColor);
+
+        return imageBitmap.Encode(format, quality).AsStream();
     }
 
     /// <summary>


### PR DESCRIPTION
Adds functionality to programmatically scroll the ChipGroup control:

- Introduces methods to scroll to a specific chip, selected chip, or a chip with a specific value.
- Implements a new SafeArea effect to handle safe area insets on iOS and MacCatalyst.
- Provides example usage in the test app to demonstrate the new scrolling features.