### PR TITLE
Invalidates control on property changes

### DIFF
--- a/AuroraControlsMaui/PlatformUnderlayDrawable.cs
+++ b/AuroraControlsMaui/PlatformUnderlayDrawable.cs
@@ -384,12 +384,16 @@ public class PlatformUnderlayDrawable : IDisposable
         if (_typeRegistration is not null && !string.IsNullOrEmpty(_typeRegistration.ValueChangeProperty) && e.PropertyName == _typeRegistration.ValueChangeProperty)
         {
             AnimateHasValue();
+            return;
         }
 
         if (e.PropertyName == nameof(Microsoft.Maui.Controls.VisualElement.IsFocused))
         {
             AnimateHasFocus();
+            return;
         }
+
+        this.Invalidate();
     }
 
     private void AnimateHasFocus()


### PR DESCRIPTION
Ensures the control is redrawn when properties change.

This prevents visual inconsistencies by forcing a redraw
after property updates, which were not being reflected
on the UI.
