### PR TITLE
Addresses CalendarPicker cutoff on iOS

### DIFF
--- a/AuroraControlsMaui/Platforms/iOS/CalendarPickerHandler.cs
+++ b/AuroraControlsMaui/Platforms/iOS/CalendarPickerHandler.cs
@@ -31,7 +31,7 @@ public partial class CalendarPickerHandler : DatePickerHandler
         if (platformView.InputView is UIDatePicker dp)
         {
             dp.AutoresizingMask = UIViewAutoresizing.None;
-            dp.LayoutMargins = new UIEdgeInsets(0, 0, 64, 0);
+            dp.LayoutMargins = new UIEdgeInsets(0, 0, SafeAreaInfo.GetSafeArea().Bottom, 0);
 
             dp.PreferredDatePickerStyle = UIDatePickerStyle.Inline;
             dp.Mode = UIDatePickerMode.Date;

--- a/AuroraControlsMaui/Platforms/iOS/SafeAreaInfo.cs
+++ b/AuroraControlsMaui/Platforms/iOS/SafeAreaInfo.cs
@@ -1,0 +1,13 @@
+using UIKit;
+
+namespace AuroraControls;
+
+public static class SafeAreaInfo
+{
+    public static UIEdgeInsets GetSafeArea()
+    {
+        var windowScene = UIApplication.SharedApplication.ConnectedScenes.ToArray().FirstOrDefault() as UIWindowScene;
+
+        return windowScene?.Windows?.FirstOrDefault()?.SafeAreaInsets ?? UIEdgeInsets.Zero;
+    }
+}


### PR DESCRIPTION
Attempts to resolve an issue where the CalendarPicker control is cut off on the bottom on certain iOS devices.

- Applies layout margins to give the bottom area additional space for safe area and attempt to prevent cutoff so the calendar is fully visible. 