### PR TITLE
Add StartOffset to ChipGroup

### DIFF
--- a/AuroraControls.TestApp/ChipGroupPage.xaml
+++ b/AuroraControls.TestApp/ChipGroupPage.xaml
@@ -158,7 +158,7 @@
                 Grid.ColumnSpan="2"
                 Text="{Binding SelectedChipsText}"
                 LineBreakMode="WordWrap" />
-                
+
             <Label
                 Grid.Row="9"
                 Grid.Column="0"
@@ -172,7 +172,7 @@
                 Grid.ColumnSpan="2"
                 Text="{Binding SelectedValuesText}"
                 LineBreakMode="WordWrap" />
-                
+
             <Button
                 Grid.Row="11"
                 Grid.Column="0"
@@ -198,6 +198,7 @@
                     AllowMultipleSelection="{Binding AllowMultipleSelection}"
                     HorizontalSpacing="{Binding HorizontalSpacing}"
                     VerticalSpacing="{Binding VerticalSpacing}"
+                    StartOffset="64"
                     ItemsSource="{Binding ChipItems}"
                     ItemTemplate="{StaticResource ChipTemplate}"
                     SelectedValue="{Binding SelectedValue, Mode=TwoWay}"

--- a/AuroraControls.TestApp/ChipGroupPage.xaml
+++ b/AuroraControls.TestApp/ChipGroupPage.xaml
@@ -198,7 +198,7 @@
                     AllowMultipleSelection="{Binding AllowMultipleSelection}"
                     HorizontalSpacing="{Binding HorizontalSpacing}"
                     VerticalSpacing="{Binding VerticalSpacing}"
-                    StartOffset="64"
+                    ChipInset="64"
                     ItemsSource="{Binding ChipItems}"
                     ItemTemplate="{StaticResource ChipTemplate}"
                     SelectedValue="{Binding SelectedValue, Mode=TwoWay}"

--- a/AuroraControlsMaui/ChipGroup.cs
+++ b/AuroraControlsMaui/ChipGroup.cs
@@ -120,17 +120,17 @@ public class ChipGroup : ContentView, IDisposable
     /// <summary>
     /// The start offset to insert empty space before the first chip.
     /// </summary>
-    public static readonly BindableProperty StartOffsetProperty =
-        BindableProperty.Create(nameof(StartOffset), typeof(double), typeof(ChipGroup), 0.0,
+    public static readonly BindableProperty ChipInsetProperty =
+        BindableProperty.Create(nameof(ChipInset), typeof(double), typeof(ChipGroup), 0.0,
             propertyChanged: OnLayoutPropertyChanged);
 
     /// <summary>
     /// Gets or sets the start offset to insert empty space before the first chip.
     /// </summary>
-    public double StartOffset
+    public double ChipInset
     {
-        get => (double)GetValue(StartOffsetProperty);
-        set => SetValue(StartOffsetProperty, value);
+        get => (double)GetValue(ChipInsetProperty);
+        set => SetValue(ChipInsetProperty, value);
     }
 
     /// <summary>
@@ -289,11 +289,7 @@ public class ChipGroup : ContentView, IDisposable
             AlignItems = FlexAlignItems.Center,
         };
 
-        // Apply start offset padding if specified
-        if (StartOffset > 0)
-        {
-            _chipContainer.Padding = new Thickness(StartOffset, 0, 0, 0);
-        }
+        ApplyChipInset();
 
         if (IsScrollable)
         {
@@ -333,6 +329,20 @@ public class ChipGroup : ContentView, IDisposable
             FlexLayout.SetShrink(chip, 0);
 
             chip.Margin = new Thickness(0, 0, this.HorizontalSpacing, this.IsScrollable ? 0 : this.VerticalSpacing);
+        }
+    }
+
+    private void ApplyChipInset()
+    {
+        if (_chipContainer == null)
+        {
+            return;
+        }
+
+        // Apply inner padding if specified
+        if (this.ChipInset > 0)
+        {
+            _chipContainer.Padding = new Thickness(this.ChipInset, 0);
         }
     }
 
@@ -894,9 +904,8 @@ public class ChipGroup : ContentView, IDisposable
 
         // Update container orientation and wrapping behavior
         _chipContainer.Wrap = IsScrollable ? FlexWrap.NoWrap : FlexWrap.Wrap;
-
-        // Update start offset padding
-        _chipContainer.Padding = new Thickness(StartOffset, 0, 0, 0);
+        
+        ApplyChipInset();
 
         // Remove or add scrollview as needed
         if (IsScrollable && Content != _scrollView)

--- a/AuroraControlsMaui/ChipGroup.cs
+++ b/AuroraControlsMaui/ChipGroup.cs
@@ -904,7 +904,7 @@ public class ChipGroup : ContentView, IDisposable
 
         // Update container orientation and wrapping behavior
         _chipContainer.Wrap = IsScrollable ? FlexWrap.NoWrap : FlexWrap.Wrap;
-        
+
         ApplyChipInset();
 
         // Remove or add scrollview as needed

--- a/AuroraControlsMaui/ChipGroup.cs
+++ b/AuroraControlsMaui/ChipGroup.cs
@@ -118,6 +118,22 @@ public class ChipGroup : ContentView, IDisposable
     }
 
     /// <summary>
+    /// The start offset to insert empty space before the first chip.
+    /// </summary>
+    public static readonly BindableProperty StartOffsetProperty =
+        BindableProperty.Create(nameof(StartOffset), typeof(double), typeof(ChipGroup), 0.0,
+            propertyChanged: OnLayoutPropertyChanged);
+
+    /// <summary>
+    /// Gets or sets the start offset to insert empty space before the first chip.
+    /// </summary>
+    public double StartOffset
+    {
+        get => (double)GetValue(StartOffsetProperty);
+        set => SetValue(StartOffsetProperty, value);
+    }
+
+    /// <summary>
     /// The source collection of items to create chips from.
     /// </summary>
     public static readonly BindableProperty ItemsSourceProperty =
@@ -272,6 +288,12 @@ public class ChipGroup : ContentView, IDisposable
             JustifyContent = FlexJustify.Start,
             AlignItems = FlexAlignItems.Center,
         };
+
+        // Apply start offset padding if specified
+        if (StartOffset > 0)
+        {
+            _chipContainer.Padding = new Thickness(StartOffset, 0, 0, 0);
+        }
 
         if (IsScrollable)
         {
@@ -872,6 +894,9 @@ public class ChipGroup : ContentView, IDisposable
 
         // Update container orientation and wrapping behavior
         _chipContainer.Wrap = IsScrollable ? FlexWrap.NoWrap : FlexWrap.Wrap;
+
+        // Update start offset padding
+        _chipContainer.Padding = new Thickness(StartOffset, 0, 0, 0);
 
         // Remove or add scrollview as needed
         if (IsScrollable && Content != _scrollView)


### PR DESCRIPTION
Add StartOffset to ChipGroup to allow for empty space to the left of chips. This is opposed to using Padding or Margin which 'clips' the Chips when they are scrolled.