### PR TITLE
Reduces minimum Chip width to ensure correct sizing for small Chips

### DIFF
--- a/AuroraControlsMaui/Chip.cs
+++ b/AuroraControlsMaui/Chip.cs
@@ -18,7 +18,7 @@ public enum ChipState
 
 public class Chip : AuroraViewBase, IDisposable
 {
-    private static readonly Size _minSize = new(52, 32);
+    private static readonly Size _minSize = new(32, 32);
 
     private readonly SKPath _backgroundPath = new();
     private readonly bool _cantHandleTouch;


### PR DESCRIPTION
Reduces the minimum Chip width to 32 to ensure proper centering & sizing for Chips containing a single character