### PR TITLE
Triggers ChipGroup selection change event correctly

### DIFF
--- a/AuroraControlsMaui/Chip.cs
+++ b/AuroraControlsMaui/Chip.cs
@@ -18,7 +18,7 @@ public enum ChipState
 
 public class Chip : AuroraViewBase, IDisposable
 {
-    private static readonly Size _minSize = new(52, 32);
+    private static readonly Size _minSize = new(32, 32);
 
     private readonly SKPath _backgroundPath = new();
     private readonly bool _cantHandleTouch;

--- a/AuroraControlsMaui/ChipGroup.cs
+++ b/AuroraControlsMaui/ChipGroup.cs
@@ -518,12 +518,12 @@ public class ChipGroup : ContentView, IDisposable
             return;
         }
 
+        // Find chip with the specified value
+        Chip? matchingChip = null;
+
         try
         {
             chipGroup._isUpdating = true;
-
-            // Find chip with the specified value
-            Chip? matchingChip = null;
 
             if (newValue != null)
             {
@@ -537,14 +537,14 @@ public class ChipGroup : ContentView, IDisposable
                     return c.Value.Equals(newValue) || newValue.Equals(c.Value);
                 });
             }
-
-            // Update selection
-            chipGroup.SelectedChip = matchingChip;
         }
         finally
         {
             chipGroup._isUpdating = false;
         }
+
+        // Update selection
+        chipGroup.SelectedChip = matchingChip;
     }
 
     /// <summary>


### PR DESCRIPTION
Ensures the `OnSelectedChipChanged` event is triggered reliably by assigning the selected chip outside of the `_isUpdating` block.

This prevents the event from being blocked when selection changes programmatically.