### PR TITLE
Enhances SVG icon handling and caching.

### DIFF
--- a/AuroraControls.TestApp/MainPage.cs
+++ b/AuroraControls.TestApp/MainPage.cs
@@ -104,7 +104,7 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
                         Children =
                         {
                             new Button { BackgroundColor = Colors.Fuchsia, }
-                                .SetSvgIcon("splatoon.svg", colorOverride: Colors.White),
+                                .SetSvgIcon("splatoon.svg", 40, colorOverride: Colors.White),
 
                             new Button { Text = "View Image Processing", }
                                 .BindClicked(async () => await this.Navigation.PushAsync(new ImageProcessing()))
@@ -264,7 +264,7 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
                                 {
                                     Opacity = .25d,
                                     BackgroundColor = Colors.Fuchsia,
-                                    ActiveColor = Colors.Red,
+                                    ActiveColor = Colors.Transparent,
                                     InactiveColor = Colors.Green,
                                     PlaceholderColor = Colors.Purple,
                                     BorderStyle = ContainerBorderStyle.RoundedRectanglePlaceholderThrough,
@@ -492,8 +492,10 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
                                 },
                             }),
                             new Tile { EmbeddedImageName = "triforce.svg", ButtonBackgroundColor = Colors.Fuchsia, },
-                            new SvgImageView { EmbeddedImageName = "splatoon.svg", OverlayColor = Colors.Chartreuse, }
+                            new SvgImageView { EmbeddedImageName = "splatoon.svg", HeightRequest = 66, OverlayColor = Colors.Chartreuse, }
                                 .Assign(out _svgImageView),
+                            new Image { HeightRequest = 66, }
+                                .SetSvgIcon("splatoon.svg", 66, Colors.Fuchsia),
                             new Button { Text = "Update Effects" }
                                 .Assign(out _svgImageViewTapped),
                             new GradientPillButton
@@ -505,8 +507,6 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
                                     FontFamily = "Clathing",
                                 }
                                 .Assign(out _pillButton),
-                            new Image()
-                                .SetSvgIcon("splatoon.svg", 66, Colors.Red),
                             new CupertinoToggleSwitch(),
                         },
                     },

--- a/AuroraControlsMaui/AuroraControlBuilder.cs
+++ b/AuroraControlsMaui/AuroraControlBuilder.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using SkiaSharp.Views.Maui.Controls.Hosting;
 
 namespace AuroraControls;
@@ -36,6 +37,11 @@ public static class AuroraControlBuilder
                         .Add<Effects.RoundedCornersEffect, RoundedCornersPlatformEffect>()
                         .Add<Effects.SafeAreaEffect, SafeAreaPlatformEffect>();
 #endif
+                })
+            .ConfigureImageSources(
+                services =>
+                {
+                    services.AddService<NoCacheFileImageSource>(svcs => new NoCacheFileImageSourceService(svcs.GetService<ILogger<NoCacheFileImageSourceService>>()));
                 });
 
         foreach (var assembly in resourceAssemblies)

--- a/AuroraControlsMaui/Extensions/ImageSourceExtensions.cs
+++ b/AuroraControlsMaui/Extensions/ImageSourceExtensions.cs
@@ -44,7 +44,7 @@ public static class ImageSourceExtensions
         return image;
     }
 
-    public static ToolbarItem AsAsyncSourceFor(this Task<FileImageSource> imageSourceTask, ToolbarItem toolbarItem)
+    public static ToolbarItem AsAsyncSourceFor(this Task<ImageSource> imageSourceTask, ToolbarItem toolbarItem)
     {
         imageSourceTask
             .ContinueWith(
@@ -60,7 +60,7 @@ public static class ImageSourceExtensions
         return toolbarItem;
     }
 
-    public static MenuItem AsAsyncSourceFor(this Task<FileImageSource> imageSourceTask, MenuItem menuItem)
+    public static MenuItem AsAsyncSourceFor(this Task<ImageSource> imageSourceTask, MenuItem menuItem)
     {
         imageSourceTask
             .ContinueWith(
@@ -92,7 +92,7 @@ public static class ImageSourceExtensions
         return page;
     }
 
-    public static Button AsAsyncSourceFor(this Task<FileImageSource> imageSourceTask, Button button)
+    public static Button AsAsyncSourceFor(this Task<ImageSource> imageSourceTask, Button button)
     {
         imageSourceTask
             .ContinueWith(
@@ -108,7 +108,7 @@ public static class ImageSourceExtensions
         return button;
     }
 
-    public static ImageButton AsAsyncSourceFor(this Task<FileImageSource> imageSourceTask, ImageButton button)
+    public static ImageButton AsAsyncSourceFor(this Task<ImageSource> imageSourceTask, ImageButton button)
     {
         imageSourceTask
             .ContinueWith(
@@ -124,7 +124,7 @@ public static class ImageSourceExtensions
         return button;
     }
 
-    public static ImageCell AsAsyncSourceFor(this Task<FileImageSource> imageSourceTask, ImageCell imageCell)
+    public static ImageCell AsAsyncSourceFor(this Task<ImageSource> imageSourceTask, ImageCell imageCell)
     {
         imageSourceTask
             .ContinueWith(
@@ -140,7 +140,7 @@ public static class ImageSourceExtensions
         return imageCell;
     }
 
-    public static void AsAsyncSourceFor(this Task<FileImageSource> imageSourceTask, Action<ImageSource> assignImageSource) =>
+    public static void AsAsyncSourceFor(this Task<ImageSource> imageSourceTask, Action<ImageSource> assignImageSource) =>
         imageSourceTask
             .ContinueWith(
                 async result =>
@@ -210,7 +210,7 @@ public static class ImageSourceExtensions
         return imageSource;
     }
 
-    public static FileImageSource AsAsyncFileImageSource(this Task<FileImageSource> imageSourceTask)
+    public static FileImageSource AsAsyncImageSource(this Task<FileImageSource> imageSourceTask)
     {
         var imageSource = new FileImageSource();
 
@@ -228,7 +228,7 @@ public static class ImageSourceExtensions
         return imageSource;
     }
 
-    public static FileImageSource AsAsyncFileImageSource(this Task<FileImageSource> imageSourceTask, FileImageSource updatableSource)
+    public static ImageSource AsAsyncImageSource(this Task<FileImageSource> imageSourceTask, FileImageSource updatableSource)
     {
         imageSourceTask
             .ContinueWith(
@@ -264,13 +264,13 @@ public static class ImageSourceExtensions
 
     public static Button SetSvgIcon(this Button imageElement, string svgName, double squareSize = 24d, Color? colorOverride = null) =>
         IconCache
-            .FileImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
+            .ImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
             .AsAsyncSourceFor(imageElement);
 
     public static ImageButton SetSvgIcon(this ImageButton imageButton, string svgName, double squareSize = 24d, Color? colorOverride = null)
     {
         IconCache
-            .FileImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
+            .ImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
             .AsAsyncSourceFor(x => imageButton.Source = x);
 
         return imageButton;
@@ -278,17 +278,17 @@ public static class ImageSourceExtensions
 
     public static ToolbarItem SetSvgIcon(this ToolbarItem toolbarItem, string svgName, double squareSize = 24d, Color? colorOverride = null) =>
         IconCache
-            .FileImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
+            .ImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
             .AsAsyncSourceFor(toolbarItem);
 
     public static MenuItem SetSvgIcon(this MenuItem menuItem, string svgName, double squareSize = 24d, Color? colorOverride = null) =>
         IconCache
-            .FileImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
+            .ImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
             .AsAsyncSourceFor(menuItem);
 
     public static Image SetSvgIcon(this Image image, string svgName, double squareSize = 24d, Color? colorOverride = null) =>
         IconCache
-            .FileImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
+            .ImageSourceFromSvg(svgName, squareSize, colorOverride: colorOverride)
             .AsAsyncSourceFor(image);
 
     public static Task<SKBitmap> BitmapFromSource(this ImageSource imageSource) => IconCache.SKBitmapFromSource(imageSource);

--- a/AuroraControlsMaui/IIconCache.cs
+++ b/AuroraControlsMaui/IIconCache.cs
@@ -35,7 +35,7 @@ public interface IIconCache
     /// <param name="squareSize">The square size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<ImageSource> SourceFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = default(Color));
+    Task<ImageSource> ImageSourceFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Fetches an SVG icon by name.
@@ -45,7 +45,7 @@ public interface IIconCache
     /// <param name="size">A Xamarin.Forms.Size representing the desired size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<ImageSource> SourceFromSvg(string svgName, Size size, string additionalCacheKey = "", Color? colorOverride = default(Color));
+    Task<ImageSource> ImageSourceFromSvg(string svgName, Size size, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Fetches an SVG icon by name.
@@ -56,7 +56,7 @@ public interface IIconCache
     /// <param name="squareSize">A double representing the desired size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<ImageSource> SourceFromRawSvg(string svgName, string svgValue, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = default(Color));
+    Task<ImageSource> ImageSourceFromRawSvg(string svgName, string svgValue, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Fetches an SVG icon by name.
@@ -67,27 +67,7 @@ public interface IIconCache
     /// <param name="size">A Xamarin.Forms.Size representing the desired size of the icon.</param>
     /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
     /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<ImageSource> SourceFromRawSvg(string svgName, string svgValue, Size size, string additionalCacheKey = "", Color? colorOverride = default(Color));
-
-    /// <summary>
-    /// Fetches an SVG file image source by name.
-    /// </summary>
-    /// <returns>The Icon as a FileImageSource.</returns>
-    /// <param name="svgName">The name of the SVG.</param>
-    /// <param name="squareSize">The square size of the icon.</param>
-    /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
-    /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<FileImageSource> FileImageSourceFromSvg(string svgName, double squareSize = 22d, string additionalCacheKey = "", Color? colorOverride = default(Color));
-
-    /// <summary>
-    /// Fetches an SVG icon by name.
-    /// </summary>
-    /// <returns>The Icon as a FileImageSource.</returns>
-    /// <param name="svgName">The name of the SVG.</param>
-    /// <param name="size">A Xamarin.Forms.Size representing the desired size of the icon.</param>
-    /// <param name="additionalCacheKey">Allows for setting an addiitonal cache key.</param>
-    /// <param name="colorOverride">Allows for setting the color of the icon.</param>
-    Task<FileImageSource> FileImageSourceFromSvg(string svgName, Size size, string additionalCacheKey = "", Color? colorOverride = default(Color));
+    Task<ImageSource> ImageSourceFromRawSvg(string svgName, string svgValue, Size size, string additionalCacheKey = "", Color? colorOverride = default(Color));
 
     /// <summary>
     /// Loads the assembly.

--- a/AuroraControlsMaui/INoCacheFileImageSource.cs
+++ b/AuroraControlsMaui/INoCacheFileImageSource.cs
@@ -1,0 +1,6 @@
+namespace AuroraControls;
+
+internal interface INoCacheFileImageSource : IImageSource
+{
+    string File { get; }
+}

--- a/AuroraControlsMaui/NoCacheFileImageSource.cs
+++ b/AuroraControlsMaui/NoCacheFileImageSource.cs
@@ -1,0 +1,48 @@
+namespace AuroraControls;
+
+internal class NoCacheFileImageSource : ImageSource, INoCacheFileImageSource
+{
+    public static readonly BindableProperty FileProperty = BindableProperty.Create(nameof(File), typeof(string), typeof(NoCacheFileImageSource), default(string));
+
+    /// <include file="../../docs/Microsoft.Maui.Controls/FileImageSource.xml" path="//Member[@MemberName='IsEmpty']/Docs/*" />
+    public override bool IsEmpty => string.IsNullOrEmpty(File);
+
+    /// <include file="../../docs/Microsoft.Maui.Controls/FileImageSource.xml" path="//Member[@MemberName='File']/Docs/*" />
+    public string File
+    {
+        get { return (string)GetValue(FileProperty); }
+        set { SetValue(FileProperty, value); }
+    }
+
+    /// <include file="../../docs/Microsoft.Maui.Controls/FileImageSource.xml" path="//Member[@MemberName='Cancel']/Docs/*" />
+    public override Task<bool> Cancel()
+    {
+        return Task.FromResult(false);
+    }
+
+    /// <include file="../../docs/Microsoft.Maui.Controls/FileImageSource.xml" path="//Member[@MemberName='ToString']/Docs/*" />
+    public override string ToString()
+    {
+        return $"File: {File}";
+    }
+
+    public static implicit operator NoCacheFileImageSource(string file)
+    {
+        return (NoCacheFileImageSource)FromFile(file);
+    }
+
+    public static implicit operator string(NoCacheFileImageSource file)
+    {
+        return file?.File;
+    }
+
+    protected override void OnPropertyChanged(string propertyName = null)
+    {
+        if (propertyName == FileProperty.PropertyName)
+        {
+            OnSourceChanged();
+        }
+
+        base.OnPropertyChanged(propertyName);
+    }
+}

--- a/AuroraControlsMaui/NoCacheFileImageSourceService.cs
+++ b/AuroraControlsMaui/NoCacheFileImageSourceService.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Logging;
+
+namespace AuroraControls;
+
+internal partial class NoCacheFileImageSourceService : ImageSourceService, IImageSourceService<NoCacheFileImageSource>
+{
+    public NoCacheFileImageSourceService()
+        : this(null)
+    {
+    }
+
+    public NoCacheFileImageSourceService(ILogger<NoCacheFileImageSourceService>? logger = null)
+        : base(logger)
+    {
+    }
+}

--- a/AuroraControlsMaui/Platforms/Android/NoCacheFileImageSourceService.cs
+++ b/AuroraControlsMaui/Platforms/Android/NoCacheFileImageSourceService.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Android.Content;
+using Android.Graphics.Drawables;
+using Android.Widget;
+using Bumptech.Glide;
+using Bumptech.Glide.Request;
+using Bumptech.Glide.Request.Target;
+using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Controls.PlatformConfiguration;
+using Microsoft.Maui.Platform;
+
+namespace AuroraControls;
+
+internal partial class NoCacheFileImageSourceService
+{
+    public override Task<IImageSourceServiceResult?> LoadDrawableAsync(IImageSource imageSource, Android.Widget.ImageView imageView,
+        CancellationToken cancellationToken = default)
+    {
+        var fileImageSource = (INoCacheFileImageSource)imageSource;
+
+        if (!fileImageSource.IsEmpty)
+        {
+            var file = fileImageSource.File;
+
+            try
+            {
+                if (!Path.IsPathRooted(file) || !File.Exists(file))
+                {
+                    var id = imageView.Context?.GetDrawableId(file) ?? -1;
+                    if (id > 0)
+                    {
+                        imageView.SetImageResource(id);
+                        return Task.FromResult<IImageSourceServiceResult?>(new ImageSourceServiceLoadResult());
+                    }
+                }
+
+                using var pathDrawable = Drawable.CreateFromPath(file);
+                imageView.SetImageDrawable(pathDrawable);
+
+                return Task.FromResult<IImageSourceServiceResult?>(new ImageSourceServiceLoadResult());
+            }
+            catch (Exception ex)
+            {
+                Logger?.LogWarning(ex, "Unable to load image file '{File}'.", file);
+                throw;
+            }
+        }
+
+        return Task.FromResult<IImageSourceServiceResult?>(null);
+    }
+
+    public override Task<IImageSourceServiceResult<Drawable>?> GetDrawableAsync(IImageSource imageSource, Context context,
+        CancellationToken cancellationToken = default)
+    {
+        var fileImageSource = (INoCacheFileImageSource)imageSource;
+        if (!fileImageSource.IsEmpty)
+        {
+            var file = fileImageSource.File;
+
+            try
+            {
+                if (!Path.IsPathRooted(file) || !File.Exists(file))
+                {
+                    var id = context?.GetDrawableId(file) ?? -1;
+                    if (id > 0)
+                    {
+                        var d = context?.GetDrawable(id);
+                        if (d is not null)
+                        {
+                            return Task.FromResult<IImageSourceServiceResult<Drawable>?>(new ImageSourceServiceResult(d));
+                        }
+                    }
+                }
+
+                var pathDrawable = Drawable.CreateFromPath(file);
+                return Task.FromResult<IImageSourceServiceResult<Drawable>?>(new ImageSourceServiceResult(pathDrawable));
+            }
+            catch (Exception ex)
+            {
+                Logger?.LogWarning(ex, "Unable to load image file '{File}'.", file);
+                throw;
+            }
+        }
+
+        return Task.FromResult<IImageSourceServiceResult<Drawable>?>(null);
+    }
+}
+
+internal class AuroraImageLoaderCallback : AuroraImageLoaderCallbackBase<IImageSourceServiceResult>
+{
+    protected override IImageSourceServiceResult? OnSuccess(Drawable? drawable, Action? dispose) =>
+        new ImageSourceServiceLoadResult(dispose);
+}
+
+internal class AuroraImageLoaderResultCallback : AuroraImageLoaderCallbackBase<IImageSourceServiceResult<Drawable>>
+{
+    protected override IImageSourceServiceResult<Drawable>? OnSuccess(Drawable? drawable, Action? dispose) =>
+        drawable is not null
+            ? new ImageSourceServiceResult(drawable, dispose)
+            : default;
+}
+
+internal abstract class AuroraImageLoaderCallbackBase<T> : Java.Lang.Object, IImageLoaderCallback
+    where T : IImageSourceServiceResult
+{
+    private readonly TaskCompletionSource<T?> _tcsResult = new();
+
+    public Task<T?> Result => _tcsResult.Task;
+
+    public void OnComplete(Java.Lang.Boolean? success, Drawable? drawable, Java.Lang.IRunnable? dispose)
+    {
+        try
+        {
+            Action? disposeWrapper = dispose != null
+                ? dispose.Run
+                : null;
+
+            var result = success?.BooleanValue() == true
+                ? OnSuccess(drawable, disposeWrapper)
+                : OnFailure(drawable, disposeWrapper);
+
+            _tcsResult.SetResult(result);
+        }
+        catch (Exception ex)
+        {
+            _tcsResult.SetException(ex);
+        }
+    }
+
+    protected abstract T? OnSuccess(Drawable? drawable, Action? dispose);
+
+    protected virtual T? OnFailure(Drawable? errorDrawable, Action? dispose) => default;
+}

--- a/AuroraControlsMaui/Platforms/MacCatalyst/NoCacheFileImageSourceService.cs
+++ b/AuroraControlsMaui/Platforms/MacCatalyst/NoCacheFileImageSourceService.cs
@@ -1,0 +1,11 @@
+using UIKit;
+
+namespace AuroraControls;
+
+internal partial class NoCacheFileImageSourceService
+{
+    public override Task<IImageSourceServiceResult<UIImage>?> GetImageAsync(IImageSource imageSource, float scale = 1, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/AuroraControlsMaui/Platforms/iOS/NoCacheFileImageSourceService.cs
+++ b/AuroraControlsMaui/Platforms/iOS/NoCacheFileImageSourceService.cs
@@ -1,0 +1,11 @@
+using UIKit;
+
+namespace AuroraControls;
+
+internal partial class NoCacheFileImageSourceService
+{
+    public override Task<IImageSourceServiceResult<UIImage>?> GetImageAsync(IImageSource imageSource, float scale = 1, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
- Introduces a new `NoCacheFileImageSource` to prevent image caching on Android, ensuring icons are always updated.
- Modifies the `IconCacheBase` to use `ImageSource` instead of `FileImageSource` for better platform compatibility.
- Updates the `SetSvgIcon` extension methods to leverage the new `ImageSource` approach.
