### PR TITLE
Fixes image loading on Android

### DIFF
--- a/AuroraControlsMaui/Platforms/Android/NoCacheFileImageSourceService.cs
+++ b/AuroraControlsMaui/Platforms/Android/NoCacheFileImageSourceService.cs
@@ -78,7 +78,7 @@ internal partial class NoCacheFileImageSourceService
                     }
                 }
 
-                var pathBitmap = await BitmapFactory.DecodeFileAsync(file);
+                var pathBitmap = BitmapFactory.DecodeFile(file);
                 var pathDrawable = new BitmapDrawable(Platform.AppContext.Resources, pathBitmap);
                 return new ImageSourceServiceResult(pathDrawable);
             }


### PR DESCRIPTION
The asynchronous image loading on Android was causing issues, so it reverts to a synchronous approach.

This resolves the issue of images not loading correctly in certain scenarios.
