### PR TITLE
Handles null image and overlay scenarios

### DIFF
--- a/AuroraControlsMaui/SvgImageView.cs
+++ b/AuroraControlsMaui/SvgImageView.cs
@@ -1,4 +1,4 @@
-﻿using Svg.Skia;
+using Svg.Skia;
 using Color = Microsoft.Maui.Graphics.Color;
 
 namespace AuroraControls;
@@ -129,7 +129,7 @@ public class SvgImageView : AuroraViewBase
 
         canvas.Clear();
 
-        if (!string.IsNullOrEmpty(_pictureName))
+        if (!string.IsNullOrEmpty(_pictureName) && _svg?.Picture != null)
         {
             float scaleAmount =
                 this.MaxImageSize == Size.Zero
@@ -144,7 +144,7 @@ public class SvgImageView : AuroraViewBase
 
             canvas.DrawPicture(_svg.Picture, ref scale);
 
-            if (OverlayColor != Colors.Transparent)
+            if (OverlayColor != Colors.Transparent && _overlayPaint != null)
             {
                 using (new SKAutoCanvasRestore(canvas))
                 {


### PR DESCRIPTION
This change prevents potential null reference exceptions by adding checks for null `_svg.Picture` and null `_overlayPaint` objects before attempting to use them.

This ensures that the application gracefully handles scenarios where the image or overlay is not properly initialized or loaded.