### PR TITLE
Defaults Segment ForegroundColor to Transparent

### DIFF
--- a/AuroraControlsMaui/CalendarView.cs
+++ b/AuroraControlsMaui/CalendarView.cs
@@ -827,7 +827,7 @@ public class CalendarView : AuroraViewBase
 
                 if (largeEvent != null)
                 {
-                    calendarEventPaint.Color = !Equals(largeEvent.Color, Colors.Transparent)
+                    calendarEventPaint.Color = largeEvent.Color is not null && !Equals(largeEvent.Color, Colors.Transparent)
                         ? largeEvent.Color.ToSKColor()
                         : SKColors.Transparent;
 

--- a/AuroraControlsMaui/Chip.cs
+++ b/AuroraControlsMaui/Chip.cs
@@ -389,7 +389,7 @@ public class Chip : AuroraViewBase
     }
 
     public static readonly BindableProperty ToggledFontColorProperty =
-        BindableProperty.Create(nameof(ToggledFontColor), typeof(Color), typeof(Chip),
+        BindableProperty.Create(nameof(ToggledFontColor), typeof(Color), typeof(Chip), Colors.Transparent,
             propertyChanged: IAuroraView.PropertyChangedInvalidateSurface);
 
     public Color ToggledFontColor
@@ -605,7 +605,7 @@ public class Chip : AuroraViewBase
             .ToSKColor();
 
         var fontColor =
-            (isToggled && !Equals(this.ToggledFontColor, Colors.Transparent)
+            (isToggled && this.ToggledFontColor is not null && !Equals(this.ToggledFontColor, Colors.Transparent)
                 ? this.ToggledFontColor
                 : isReadonly
                     ? this.ReadOnlyFontColor
@@ -613,7 +613,7 @@ public class Chip : AuroraViewBase
             .ToSKColor();
 
         var borderColor =
-            (isToggled && !Equals(this.ToggledBorderColor, Colors.Transparent)
+            (isToggled && this.ToggledBorderColor is not null && !Equals(this.ToggledBorderColor, Colors.Transparent)
                 ? this.ToggledBorderColor
                 : isReadonly
                     ? this.ReadOnlyBorderColor

--- a/AuroraControlsMaui/CupertinoTextToggleSwitch.cs
+++ b/AuroraControlsMaui/CupertinoTextToggleSwitch.cs
@@ -201,7 +201,7 @@ public class CupertinoTextToggleSwitch : AuroraViewBase
     }
 
     public static readonly BindableProperty EnabledFontColorProperty =
-        BindableProperty.Create(nameof(EnabledFontColor), typeof(Color), typeof(CupertinoTextToggleSwitch),
+        BindableProperty.Create(nameof(EnabledFontColor), typeof(Color), typeof(CupertinoTextToggleSwitch), Colors.Transparent,
             propertyChanged: IAuroraView.PropertyChangedInvalidateSurface);
 
     public Color EnabledFontColor
@@ -397,7 +397,7 @@ public class CupertinoTextToggleSwitch : AuroraViewBase
         if (!string.IsNullOrEmpty(EnabledText))
         {
             var fontColor =
-                (!Equals(this.EnabledFontColor, Colors.Transparent)
+                (this.EnabledFontColor is not null && !Equals(this.EnabledFontColor, Colors.Transparent)
                     ? EnabledFontColor
                     : DisabledFontColor)
                     .ToSKColor()

--- a/AuroraControlsMaui/CutoutOverlayView.cs
+++ b/AuroraControlsMaui/CutoutOverlayView.cs
@@ -249,7 +249,7 @@ public class CutoutOverlayView : AuroraViewBase
             canvas.DrawPaint(overlayPaint);
         }
 
-        if (this.BorderWidth > 0d && !Equals(this.BorderColor, Colors.Transparent))
+        if (this.BorderWidth > 0d && this.BorderColor is not null && !Equals(this.BorderColor, Colors.Transparent))
         {
             using var borderPaint = new SKPaint();
             borderPaint.IsAntialias = true;

--- a/AuroraControlsMaui/GradientPillButton.cs
+++ b/AuroraControlsMaui/GradientPillButton.cs
@@ -38,7 +38,7 @@ public class GradientPillButton : AuroraViewBase
     /// The button background end color property.
     /// </summary>
     public static readonly BindableProperty ButtonBackgroundEndColorProperty =
-        BindableProperty.Create(nameof(ButtonBackgroundEndColor), typeof(Color), typeof(GradientPillButton),
+        BindableProperty.Create(nameof(ButtonBackgroundEndColor), typeof(Color), typeof(GradientPillButton), Colors.Transparent,
             propertyChanged: IAuroraView.PropertyChangedInvalidateSurface);
 
     /// <summary>

--- a/AuroraControlsMaui/IconCacheBase.cs
+++ b/AuroraControlsMaui/IconCacheBase.cs
@@ -284,7 +284,7 @@ public abstract class IconCacheBase : IIconCache, IDisposable
         canvas.DrawPicture(skSvg.Picture);
 
         // Apply color override if needed
-        if (!Equals(colorOverride, Colors.Transparent))
+        if (colorOverride is not null && !Equals(colorOverride, Colors.Transparent))
         {
             _paint.Color = colorOverride.ToSKColor();
             canvas.DrawPaint(_paint);

--- a/AuroraControlsMaui/SegmentedControl.cs
+++ b/AuroraControlsMaui/SegmentedControl.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using Svg.Skia;
@@ -494,7 +494,7 @@ public class Segment : BindableObject, IDisposable
     }
 
     public static readonly BindableProperty ForegroundColorProperty =
-        BindableProperty.Create(nameof(ForegroundColor), typeof(Color), typeof(Segment));
+        BindableProperty.Create(nameof(ForegroundColor), typeof(Color), typeof(Segment), Colors.Transparent);
 
     public Color ForegroundColor
     {

--- a/AuroraControlsMaui/SegmentedControl.cs
+++ b/AuroraControlsMaui/SegmentedControl.cs
@@ -245,7 +245,7 @@ public class SegmentedControl : AuroraViewBase
                 bool selected = i == this.SelectedIndex;
 
                 var segmentForegroundColor =
-                    !Equals(segment.ForegroundColor, Colors.Transparent)
+                    segment.ForegroundColor is not null && !Equals(segment.ForegroundColor, Colors.Transparent)
                         ? segment.ForegroundColor.ToSKColor()
                         : foregroundColor;
 
@@ -457,7 +457,7 @@ public class Segment : BindableObject, IDisposable
     }
 
     public static readonly BindableProperty IsIconifiedTextProperty =
-        BindableProperty.Create(nameof(IsIconifiedText), typeof(bool), typeof(Segment), default(bool));
+        BindableProperty.Create(nameof(IsIconifiedText), typeof(bool), typeof(Segment), false);
 
     public bool IsIconifiedText
     {
@@ -503,7 +503,7 @@ public class Segment : BindableObject, IDisposable
     }
 
     public static readonly BindableProperty IsSpacerProperty =
-        BindableProperty.Create(nameof(IsSpacer), typeof(bool), typeof(Segment), default(bool));
+        BindableProperty.Create(nameof(IsSpacer), typeof(bool), typeof(Segment), false);
 
     public bool IsSpacer
     {

--- a/AuroraControlsMaui/TouchDrawLettersImage.cs
+++ b/AuroraControlsMaui/TouchDrawLettersImage.cs
@@ -218,13 +218,13 @@ public class TouchDrawLettersImage : AuroraViewBase
                         (float)touchLocationX - halfScaledTouchSize, (float)touchLocationY - halfScaledTouchSize,
                         (float)touchLocationX + halfScaledTouchSize, (float)touchLocationY + halfScaledTouchSize);
 
-                    paint.Color = !Equals(touchDrawLetter.BackgroundColorOverride, Colors.Transparent)
+                    paint.Color = touchDrawLetter.BackgroundColorOverride is not null && !Equals(touchDrawLetter.BackgroundColorOverride, Colors.Transparent)
                         ? touchDrawLetter.BackgroundColorOverride.ToSKColor()
                         : this.DrawItemBackgroundColor.ToSKColor();
                     paint.Style = SKPaintStyle.Fill;
                     canvas.DrawOval(drawLocationRect, paint);
 
-                    paint.Color = !Equals(touchDrawLetter.ForegroundColorOverride, Colors.Transparent)
+                    paint.Color = touchDrawLetter is not null && !Equals(touchDrawLetter.ForegroundColorOverride, Colors.Transparent)
                         ? touchDrawLetter.ForegroundColorOverride.ToSKColor()
                         : this.DrawItemForegroundColor.ToSKColor();
                     paint.Style = SKPaintStyle.Stroke;
@@ -240,7 +240,7 @@ public class TouchDrawLettersImage : AuroraViewBase
                             drawPath.AddOval(drawLocationRect);
                             canvas.ClipPath(drawPath);
 
-                            paint.Color = !Equals(touchDrawLetter.ForegroundColorOverride, Colors.Transparent)
+                            paint.Color = touchDrawLetter is not null && !Equals(touchDrawLetter.ForegroundColorOverride, Colors.Transparent)
                                 ? touchDrawLetter.ForegroundColorOverride.ToSKColor()
                                 : this.DrawItemForegroundColor.ToSKColor();
                             paint.Style = SKPaintStyle.Fill;


### PR DESCRIPTION
Ensures the Segment ForegroundColor defaults to Transparent.

This prevents potential null reference issues when the ForegroundColor is not explicitly set.