### PR TITLE
Calendar Picker - Implemented immediate update mode

### DIFF
--- a/AuroraControls.TestApp/MainPage.cs
+++ b/AuroraControls.TestApp/MainPage.cs
@@ -227,7 +227,7 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
                                 Content =
                                     new CalendarPicker()
                                     {
-                                        DateUpdateMode = CalendarPickerUpdateMode.WhenDone,
+                                        UpdateMode = CalendarPickerUpdateMode.Immediately,
                                     }
                                         .Assign(out _calendarPicker),
                             },

--- a/AuroraControls.TestApp/MainPage.cs
+++ b/AuroraControls.TestApp/MainPage.cs
@@ -83,6 +83,8 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
 
     private CalendarPicker _calendarPicker;
 
+    private Label _calendarPickerValue;
+
     private Button _clearNullableDatePicker;
 
     public MainPage(ILogger<TestRxViewModel> logger)
@@ -224,8 +226,13 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
                                 Placeholder = "Nullable Date Picker",
                                 Content =
                                     new CalendarPicker()
+                                    {
+                                        DateUpdateMode = CalendarPickerUpdateMode.WhenDone,
+                                    }
                                         .Assign(out _calendarPicker),
                             },
+                            new Label()
+                                .Assign(out _calendarPickerValue),
                             new Button { Text = "Clear Nullable Date Picker", }
                                 .Assign(out _clearNullableDatePicker),
                             new StyledInputLayout
@@ -544,6 +551,10 @@ public class MainPage : ReactiveContentPage<TestRxViewModel>
                         },
                     },
             };
+
+        this.Bind(ViewModel, x => x.NullableDateTimeValue, x => x._calendarPicker.Date);
+
+        this.OneWayBind(ViewModel, x => x.NullableDateTimeValue, x => x._calendarPickerValue.Text, x => x?.ToString("D") ?? "null");
 
         _clearNullableDatePicker.Clicked +=
             (sender, args) => { _calendarPicker.Date = null; };

--- a/AuroraControlsMaui/CalendarPicker.cs
+++ b/AuroraControlsMaui/CalendarPicker.cs
@@ -2,19 +2,19 @@ namespace AuroraControls;
 
 public enum CalendarPickerUpdateMode
 {
-    Immediately = 1,
-    WhenDone = 2,
+    WhenDone = 1,
+    Immediately = 2,
 }
 
 [ContentProperty(nameof(Date))]
 public class CalendarPicker : DatePicker
 {
-    public static readonly BindableProperty CalendarPickerUpdateModeProperty =
+    public static readonly BindableProperty UpdateModeProperty =
         BindableProperty.Create(
             nameof(CalendarPickerUpdateMode),
             typeof(CalendarPickerUpdateMode),
             typeof(CalendarPicker),
-            CalendarPickerUpdateMode.Immediately);
+            CalendarPickerUpdateMode.WhenDone);
 
     /// <summary>
     /// Gets or sets the mode to use for determining when to update the Date:
@@ -22,10 +22,10 @@ public class CalendarPicker : DatePicker
     /// 2. WhenDone - Update Date when the 'Done' button is pressed.
     /// </summary>
     /// <remarks>Only applies on iOS.</remarks>
-    public CalendarPickerUpdateMode DateUpdateMode
+    public CalendarPickerUpdateMode UpdateMode
     {
-        get => (CalendarPickerUpdateMode)GetValue(CalendarPickerUpdateModeProperty);
-        set => SetValue(CalendarPickerUpdateModeProperty, value);
+        get => (CalendarPickerUpdateMode)GetValue(UpdateModeProperty);
+        set => SetValue(UpdateModeProperty, value);
     }
 
     public new event EventHandler<NullableDateChangedEventArgs> DateSelected;

--- a/AuroraControlsMaui/CalendarPicker.cs
+++ b/AuroraControlsMaui/CalendarPicker.cs
@@ -1,8 +1,33 @@
 namespace AuroraControls;
 
+public enum CalendarPickerUpdateMode
+{
+    Immediately = 1,
+    WhenDone = 2,
+}
+
 [ContentProperty(nameof(Date))]
 public class CalendarPicker : DatePicker
 {
+    public static readonly BindableProperty CalendarPickerUpdateModeProperty =
+        BindableProperty.Create(
+            nameof(CalendarPickerUpdateMode),
+            typeof(CalendarPickerUpdateMode),
+            typeof(CalendarPicker),
+            CalendarPickerUpdateMode.Immediately);
+
+    /// <summary>
+    /// Gets or sets the mode to use for determining when to update the Date:
+    /// 1. Immediately - Update Date when a date is selected.
+    /// 2. WhenDone - Update Date when the 'Done' button is pressed.
+    /// </summary>
+    /// <remarks>Only applies on iOS.</remarks>
+    public CalendarPickerUpdateMode DateUpdateMode
+    {
+        get => (CalendarPickerUpdateMode)GetValue(CalendarPickerUpdateModeProperty);
+        set => SetValue(CalendarPickerUpdateModeProperty, value);
+    }
+
     public new event EventHandler<NullableDateChangedEventArgs> DateSelected;
 
     /// <summary>

--- a/AuroraControlsMaui/Platforms/iOS/CalendarPickerHandler.cs
+++ b/AuroraControlsMaui/Platforms/iOS/CalendarPickerHandler.cs
@@ -75,7 +75,7 @@ public partial class CalendarPickerHandler : DatePickerHandler
     {
         if (sender is UIDatePicker datePicker && this.VirtualView is CalendarPicker calendarPicker)
         {
-            if (calendarPicker.DateUpdateMode == CalendarPickerUpdateMode.Immediately)
+            if (calendarPicker.UpdateMode == CalendarPickerUpdateMode.Immediately)
             {
                 calendarPicker.Date = datePicker.Date.ToDateTime();
 

--- a/AuroraControlsMaui/Platforms/iOS/CalendarPickerHandler.cs
+++ b/AuroraControlsMaui/Platforms/iOS/CalendarPickerHandler.cs
@@ -34,6 +34,9 @@ public partial class CalendarPickerHandler : DatePickerHandler
 
             dp.PreferredDatePickerStyle = UIDatePickerStyle.Inline;
             dp.Mode = UIDatePickerMode.Date;
+
+            // Add ValueChanged event handler to update the Date when user selects from calendar
+            dp.ValueChanged += OnDatePickerValueChanged;
         }
 
         if (platformView.InputAccessoryView is UIToolbar tb)
@@ -49,13 +52,37 @@ public partial class CalendarPickerHandler : DatePickerHandler
                     el.Unfocus();
                     el.Date = null;
                 });
+
             var items = new List<UIBarButtonItem>(tb.Items);
             items.Insert(0, clearButton);
             tb.Items = items.ToArray();
         }
     }
 
+    protected override void DisconnectHandler(MauiDatePicker platformView)
+    {
+        if (platformView.InputView is UIDatePicker dp)
+        {
+            dp.ValueChanged -= OnDatePickerValueChanged;
+        }
+
+        base.DisconnectHandler(platformView);
+    }
+
     public static void MapDate(CalendarPickerHandler handler, CalendarPicker view) => handler.TryShowEmptyState();
+
+    private void OnDatePickerValueChanged(object sender, EventArgs e)
+    {
+        if (sender is UIDatePicker datePicker && this.VirtualView is CalendarPicker calendarPicker)
+        {
+            if (calendarPicker.DateUpdateMode == CalendarPickerUpdateMode.Immediately)
+            {
+                calendarPicker.Date = datePicker.Date.ToDateTime();
+
+                TryShowEmptyState();
+            }
+        }
+    }
 
     public void TryShowEmptyState()
     {


### PR DESCRIPTION
Implemented DateUpdateMode property to allow selection of update modes. "Immediately" updates date immediately after user selects a date.  "WhenDone" updates date when the user taps the 'Done' button.