### PR TITLE
Ensure Android hardware acceleration check only returns false when absolutely necessary

### DIFF
--- a/AuroraControlsMaui/Extensions/ImageSourceExtensions.cs
+++ b/AuroraControlsMaui/Extensions/ImageSourceExtensions.cs
@@ -338,13 +338,11 @@ public static class ImageSourceExtensions
 
 #if ANDROID
         supportsHardwareAcceleration =
-            view.Handler?.PlatformView is Android.Views.View
-            {
-                IsHardwareAccelerated: true,
-                LayerType: Android.Views.LayerType.Hardware,
-            };
+            (view.Handler?.PlatformView is Android.Views.View androidView)
+                ? androidView.IsHardwareAccelerated
+                : true;
 #if DEBUG
-        Console.WriteLine($"Control is hardware accelerated: {supportsHardwareAcceleration}");
+        Console.WriteLine($"Control is hardware accelerated: {supportsHardwareAcceleration} (Handler: {view.Handler != null}, PlatformView: {view.Handler?.PlatformView != null})");
 #endif
 #endif
 


### PR DESCRIPTION
- Removed LayerType.Hardware check as it can be false but still support hardware acceleration via global settings.
- Fallback to true as it is safer as it rarely causes fatal errors.
- Improved debugging output
