### PR TITLE
Registers nullable TimePicker for StyledInputLayout

### DIFF
--- a/AuroraControlsMaui/StyledInputLayout.cs
+++ b/AuroraControlsMaui/StyledInputLayout.cs
@@ -1,4 +1,4 @@
-﻿namespace AuroraControls;
+namespace AuroraControls;
 
 public class StyledInputLayout : ContentView, IUnderlayDrawable
 {
@@ -15,7 +15,11 @@ public class StyledInputLayout : ContentView, IUnderlayDrawable
                     nameof(CalendarPicker.Date),
                     view => view.Date.HasValue,
                     false),
-            [typeof(IDatePicker)] = StyledContentTypeRegistration.Default,
+            [typeof(IDatePicker)] =
+                StyledContentTypeRegistration.Build<IDatePicker>(
+                    nameof(IDatePicker.Date),
+                    view => view.Date.HasValue,
+                    false),
             [typeof(ITimePicker)] =
                 StyledContentTypeRegistration.Build<TimePicker>(
                     nameof(TimePicker.Time),

--- a/AuroraControlsMaui/StyledInputLayout.cs
+++ b/AuroraControlsMaui/StyledInputLayout.cs
@@ -16,7 +16,11 @@ public class StyledInputLayout : ContentView, IUnderlayDrawable
                     view => view.Date.HasValue,
                     false),
             [typeof(IDatePicker)] = StyledContentTypeRegistration.Default,
-            [typeof(ITimePicker)] = StyledContentTypeRegistration.Default,
+            [typeof(ITimePicker)] =
+                StyledContentTypeRegistration.Build<TimePicker>(
+                    nameof(TimePicker.Time),
+                    view => view.Time.HasValue,
+                    false),
             [typeof(Editor)] =
                 StyledContentTypeRegistration.Build<Editor>(
                     nameof(Editor.Text),

--- a/AuroraControlsMaui/StyledInputLayout.cs
+++ b/AuroraControlsMaui/StyledInputLayout.cs
@@ -1,4 +1,4 @@
-namespace AuroraControls;
+﻿namespace AuroraControls;
 
 public class StyledInputLayout : ContentView, IUnderlayDrawable
 {
@@ -21,8 +21,8 @@ public class StyledInputLayout : ContentView, IUnderlayDrawable
                     view => view.Date.HasValue,
                     false),
             [typeof(ITimePicker)] =
-                StyledContentTypeRegistration.Build<TimePicker>(
-                    nameof(TimePicker.Time),
+                StyledContentTypeRegistration.Build<ITimePicker>(
+                    nameof(ITimePicker.Time),
                     view => view.Time.HasValue,
                     false),
             [typeof(Editor)] =


### PR DESCRIPTION
Registers the `TimePicker` control within `StyledInputLayout` to properly handle nullable `Time` values. This ensures that the layout correctly displays and manages `TimePicker` instances where the time can be null.