### PR TITLE
Adds font properties to CalendarPicker

### DIFF
--- a/AuroraControls.TestApp/Pages/Calendar/CalendarPickerDemoPage.xaml
+++ b/AuroraControls.TestApp/Pages/Calendar/CalendarPickerDemoPage.xaml
@@ -82,7 +82,7 @@
                                                        HorizontalOptions="Center"
                                                        UpdateMode="WhenDone"
                                                        DateSelected="OnDateSelected"
-                                                       FontSize="10"
+                                                       FontSize="16"
                                                        FontAttributes="Bold"
                                                        FontFamily="Helvetica"/>
 

--- a/AuroraControls.TestApp/Pages/Calendar/CalendarPickerDemoPage.xaml
+++ b/AuroraControls.TestApp/Pages/Calendar/CalendarPickerDemoPage.xaml
@@ -81,7 +81,10 @@
                                                        WidthRequest="200"
                                                        HorizontalOptions="Center"
                                                        UpdateMode="WhenDone"
-                                                       DateSelected="OnDateSelected"/>
+                                                       DateSelected="OnDateSelected"
+                                                       FontSize="10"
+                                                       FontAttributes="Bold"
+                                                       FontFamily="Helvetica"/>
 
                                 <!-- Selected Date Display -->
                                 <Border BackgroundColor="{AppThemeBinding Light={StaticResource Light.Surface}, Dark={StaticResource Dark.Surface}}"

--- a/AuroraControlsMaui/Platforms/Android/CalendarPickerHandler.cs
+++ b/AuroraControlsMaui/Platforms/Android/CalendarPickerHandler.cs
@@ -1,4 +1,5 @@
 using Android.App;
+using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
 
 namespace AuroraControls;
@@ -9,6 +10,9 @@ public partial class CalendarPickerHandler : DatePickerHandler
         new(ViewMapper)
         {
             [nameof(CalendarPicker.Date)] = MapDate,
+            [nameof(CalendarPicker.FontSize)] = MapFontSize,
+            [nameof(CalendarPicker.FontFamily)] = MapFontFamily,
+            [nameof(CalendarPicker.FontAttributes)] = MapFontAttributes,
         };
 
     public CalendarPickerHandler()
@@ -36,6 +40,69 @@ public partial class CalendarPickerHandler : DatePickerHandler
     }
 
     public static void MapDate(CalendarPickerHandler handler, CalendarPicker view) => handler.TryShowEmptyState();
+
+    public static void MapFontSize(CalendarPickerHandler handler, CalendarPicker view)
+    {
+        if (handler.PlatformView != null)
+        {
+            ApplyFont(handler, view);
+        }
+    }
+
+    public static void MapFontFamily(CalendarPickerHandler handler, CalendarPicker view)
+    {
+        if (handler.PlatformView != null)
+        {
+            ApplyFont(handler, view);
+        }
+    }
+
+    public static void MapFontAttributes(CalendarPickerHandler handler, CalendarPicker view)
+    {
+        if (handler.PlatformView != null)
+        {
+            ApplyFont(handler, view);
+        }
+    }
+
+    private static void ApplyFont(CalendarPickerHandler handler, CalendarPicker view)
+    {
+        handler.PlatformView.SetTextSize(Android.Util.ComplexUnitType.Sp, (float)view.FontSize);
+
+        var typeface = GetTypeface(view);
+        if (typeface != null)
+        {
+            handler.PlatformView.Typeface = typeface;
+        }
+    }
+
+    private static Android.Graphics.Typeface? GetTypeface(CalendarPicker view)
+    {
+        var fontFamily = view.FontFamily;
+        var fontAttributes = view.FontAttributes;
+
+        if (string.IsNullOrEmpty(fontFamily))
+        {
+            return fontAttributes switch
+            {
+                FontAttributes.Bold => Android.Graphics.Typeface.DefaultBold,
+                FontAttributes.Italic => Android.Graphics.Typeface.Create(Android.Graphics.Typeface.Default, Android.Graphics.TypefaceStyle.Italic),
+                _ => Android.Graphics.Typeface.Default,
+            };
+        }
+
+        var typeface = Android.Graphics.Typeface.Create(fontFamily, Android.Graphics.TypefaceStyle.Normal);
+        if (fontAttributes == FontAttributes.Bold)
+        {
+            typeface = Android.Graphics.Typeface.Create(typeface, Android.Graphics.TypefaceStyle.Bold);
+        }
+        else if (fontAttributes == FontAttributes.Italic)
+        {
+            typeface = Android.Graphics.Typeface.Create(typeface, Android.Graphics.TypefaceStyle.Italic);
+        }
+
+        return typeface;
+    }
 
     public void TryShowEmptyState()
     {

--- a/AuroraControlsMaui/Platforms/iOS/CalendarPickerHandler.cs
+++ b/AuroraControlsMaui/Platforms/iOS/CalendarPickerHandler.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using UIKit;
@@ -13,6 +14,9 @@ public partial class CalendarPickerHandler : DatePickerHandler, IDisposable
         new(ViewMapper)
         {
             [nameof(CalendarPicker.Date)] = MapDate,
+            [nameof(CalendarPicker.FontSize)] = MapFontSize,
+            [nameof(CalendarPicker.FontFamily)] = MapFontFamily,
+            [nameof(CalendarPicker.FontAttributes)] = MapFontAttributes,
         };
 
     public CalendarPickerHandler()
@@ -88,6 +92,77 @@ public partial class CalendarPickerHandler : DatePickerHandler, IDisposable
     }
 
     public static void MapDate(CalendarPickerHandler handler, CalendarPicker view) => handler.TryShowEmptyState();
+
+    public static void MapFontSize(CalendarPickerHandler handler, CalendarPicker view)
+    {
+        if (handler.PlatformView != null)
+        {
+            var font = GetUIFont(view);
+            handler.PlatformView.Font = font;
+        }
+    }
+
+    public static void MapFontFamily(CalendarPickerHandler handler, CalendarPicker view)
+    {
+        if (handler.PlatformView != null)
+        {
+            var font = GetUIFont(view);
+            handler.PlatformView.Font = font;
+        }
+    }
+
+    public static void MapFontAttributes(CalendarPickerHandler handler, CalendarPicker view)
+    {
+        if (handler.PlatformView != null)
+        {
+            var font = GetUIFont(view);
+            handler.PlatformView.Font = font;
+        }
+    }
+
+    private static UIKit.UIFont GetUIFont(CalendarPicker view)
+    {
+        var fontSize = (nfloat)view.FontSize;
+        var fontFamily = view.FontFamily;
+        var fontAttributes = view.FontAttributes;
+
+        if (string.IsNullOrEmpty(fontFamily))
+        {
+            if (fontAttributes == FontAttributes.Bold)
+            {
+                return UIKit.UIFont.BoldSystemFontOfSize(fontSize);
+            }
+            else if (fontAttributes == FontAttributes.Italic)
+            {
+                return UIKit.UIFont.ItalicSystemFontOfSize(fontSize);
+            }
+            else
+            {
+                return UIKit.UIFont.SystemFontOfSize(fontSize);
+            }
+        }
+        else
+        {
+            var font = UIKit.UIFont.FromName(fontFamily, fontSize);
+            if (font != null)
+            {
+                if (fontAttributes == FontAttributes.Bold)
+                {
+                    var descriptor = font.FontDescriptor.CreateWithTraits(UIKit.UIFontDescriptorSymbolicTraits.Bold);
+                    font = UIKit.UIFont.FromDescriptor(descriptor, fontSize);
+                }
+                else if (fontAttributes == FontAttributes.Italic)
+                {
+                    var descriptor = font.FontDescriptor.CreateWithTraits(UIKit.UIFontDescriptorSymbolicTraits.Italic);
+                    font = UIKit.UIFont.FromDescriptor(descriptor, fontSize);
+                }
+
+                return font;
+            }
+
+            return UIKit.UIFont.SystemFontOfSize(fontSize);
+        }
+    }
 
     private void OnDatePickerValueChanged(object sender, EventArgs e)
     {


### PR DESCRIPTION
Adds support for FontSize, FontFamily, and FontAttributes properties to the CalendarPicker control on Android and iOS.

These changes enable developers to customize the appearance of the CalendarPicker's text.